### PR TITLE
GH-13: Fix `@EnableRetry` do not proxy all beans

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -114,7 +114,12 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 	@Override
 	public Object invoke(MethodInvocation invocation) throws Throwable {
 		MethodInterceptor delegate = getDelegate(invocation.getThis(), invocation.getMethod());
-		return delegate.invoke(invocation);
+		if (delegate != null) {
+			return delegate.invoke(invocation);
+		}
+		else {
+			return invocation.proceed();
+		}
 	}
 
 	private MethodInterceptor getDelegate(Object target, Method method) {
@@ -124,6 +129,9 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 					Retryable retryable = AnnotationUtils.findAnnotation(method, Retryable.class);
 					if (retryable == null) {
 						retryable = AnnotationUtils.findAnnotation(method.getDeclaringClass(), Retryable.class);
+					}
+					if (retryable == null) {
+						return this.delegates.put(method, null);
 					}
 					MethodInterceptor delegate;
 					if (StringUtils.hasText(retryable.interceptor())) {

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
@@ -17,6 +17,7 @@
 package org.springframework.retry.annotation;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -43,6 +44,8 @@ public class EnableRetryTests {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
 				TestConfiguration.class);
 		Service service = context.getBean(Service.class);
+		Foo foo = context.getBean(Foo.class);
+		assertFalse(AopUtils.isAopProxy(foo));
 		service.service();
 		assertEquals(3, service.getCount());
 		context.close();
@@ -145,7 +148,7 @@ public class EnableRetryTests {
 	protected static class TestConfiguration {
 
 		@Bean
-		public Sleeper sleper() {
+		public Sleeper sleeper() {
 			return new Sleeper() {
 				@Override
 				public void sleep(long period) throws InterruptedException {
@@ -189,6 +192,12 @@ public class EnableRetryTests {
 		public InterceptableService serviceWithExternalInterceptor() {
 			return new InterceptableService();
 		}
+
+		@Bean
+		public Foo foo() {
+			return new Foo();
+		}
+
 	}
 
 	protected static class Service {
@@ -302,4 +311,9 @@ public class EnableRetryTests {
 		}
 
 	}
+
+	private static class Foo {
+
+	}
+
 }


### PR DESCRIPTION
Fixes https://github.com/spring-projects/spring-retry/issues/13

Previously the `@EnableRetry` caused to proxy **all** beans in the context, because
of `IntroductionAdvisor` nature in the `AopUtils` logic and simple `ClassFilter.TRUE`
in that case. In the end it just skipped `MethodMatcher` and applied `ProxyFactory` for any bean.

Since we can't avoid `IntroductionAdvisor` because of `getInterfaces()` introduction,
provide a new internal `AnnotationClassOrMethodFilter` to apply both class and method level annotation filter at once.

Polishing for the `AnnotationAwareRetryOperationsInterceptor` to skip non-`@Retryable` methods and just call `invocation.proceed()`
