### PR TITLE
Support for @Retryable in proxied beans

### DIFF
--- a/src/test/java/org/springframework/retry/annotation/EnableRetryForProxiedBeansTest.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryForProxiedBeansTest.java
@@ -1,0 +1,69 @@
+package org.springframework.retry.annotation;
+
+import org.junit.Test;
+import org.springframework.aop.framework.ProxyFactoryBean;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author Sparkbit.pl
+ */
+public class EnableRetryForProxiedBeansTest {
+
+    @Test
+    public void proxiedService() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(
+                ProxiedTestConfiguration.class);
+
+        IService service = context.getBean("proxied", IService.class);
+        service.service();
+        assertEquals(3, service.getCount());
+
+        context.close();
+    }
+
+    @Configuration
+    @EnableRetry
+    protected static class ProxiedTestConfiguration {
+        @Bean(name = "realService")
+        public IService realService() {
+            return new ServiceWithInterface();
+        }
+
+        @Bean(name = "proxied")
+        public IService service(@Qualifier("realService") IService service) {
+            ProxyFactoryBean pfb = new ProxyFactoryBean();
+            pfb.setTarget(service);
+            pfb.setInterfaces(IService.class);
+            IService proxied = (IService) pfb.getObject();
+            return proxied;
+        }
+    }
+
+    protected static interface IService {
+        void service();
+
+        int getCount();
+    }
+
+    protected static class ServiceWithInterface implements IService {
+
+        private int count = 0;
+
+        @Retryable(RuntimeException.class)
+        public void service() {
+            if (count++ < 2) {
+                throw new RuntimeException("Planned");
+            }
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+    }
+}


### PR DESCRIPTION
This change makes it possible to find the @Retryable annotation even if
the bean originally containing it is wrapped in a proxy object. It is
useful, when the annotation is added to a method in a class and
interface proxies are used. This happens when one uses @Retryable and
@Transactional on a method implementation and proxy-target-class is set
to false.