### PR TITLE
Fix bug BATCH-2030

### DIFF
--- a/src/main/java/org/springframework/classify/util/MethodInvokerUtils.java
+++ b/src/main/java/org/springframework/classify/util/MethodInvokerUtils.java
@@ -20,6 +20,7 @@ import java.lang.annotation.Annotation;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Target;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.springframework.aop.framework.Advised;
@@ -195,6 +196,10 @@ public class MethodInvokerUtils {
 		final AtomicReference<Method> methodHolder = new AtomicReference<Method>();
 		ReflectionUtils.doWithMethods(target.getClass(), new ReflectionUtils.MethodCallback() {
 			public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
+				if ((method.getModifiers() & Modifier.PUBLIC) == 0 || method.isBridge()) {
+					// perform the operation on public method only and skip bridge method
+					return;
+				}
 				if (method.getParameterTypes() == null || method.getParameterTypes().length != 1) {
 					return;
 				}

--- a/src/test/java/org/springframework/classify/BackToBackPatternClassifierTests.java
+++ b/src/test/java/org/springframework/classify/BackToBackPatternClassifierTests.java
@@ -68,4 +68,22 @@ public class BackToBackPatternClassifierTests {
 		assertEquals("spam", classifier.classify("oof"));
 	}
 
+	@Test
+	public void testSetRouterDelegateSingleMethodWithNoAnnotation() {
+		classifier = new BackToBackPatternClassifier<String, String>();
+		classifier.setRouterDelegate(new RouterDelegate());
+		classifier.setMatcherMap(map);
+		assertEquals("spam", classifier.classify("oof"));
+	}
+
+	private class RouterDelegate implements
+			org.springframework.classify.Classifier<Object, String> {
+
+		@Override
+		public String classify(Object classifiable) {
+			return "bucket";
+		}
+
+	}
+
 }


### PR DESCRIPTION
As reported in BATCH-2030, if BackToBackPatternClassifier has a delegate that inherits from "org.springframework.classify.Classifier", the 
context creation fails with the Exception "java.lang.IllegalStateException: More than one non-void public method detected with single argument". 
The reason is a problem in MethodInvokerUtils.getMethodInvokerForSingleArgument. Since "org.springframework.classify.Classifier" is a generic interface, class that extends from it is compiled to two public "classify" method: the bridge method and the bridged method. And in another case, this exception is also raised in IBM JVM because of the method "private java.lang.Object java.lang.Object.newInstancePrototype(java.lang.Class)".
