### PR TITLE
Allow to access method metadata in retry listener

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,7 @@
 	<properties>
 		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<spring.framework.version>4.0.4.RELEASE</spring.framework.version>
+		<maven.javadoc.failOnError>false</maven.javadoc.failOnError>
 	</properties>
 	<profiles>
 		<profile>

--- a/src/main/java/org/springframework/retry/RetryCallback.java
+++ b/src/main/java/org/springframework/retry/RetryCallback.java
@@ -16,22 +16,30 @@
 
 package org.springframework.retry;
 
+import org.aopalliance.intercept.MethodInvocation;
+
 /**
  * Callback interface for an operation that can be retried using a
  * {@link RetryOperations}.
- * 
+ *
  * @author Rob Harrop
  * @author Dave Syer
  */
 public interface RetryCallback<T, E extends Throwable> {
 
-	/**
-	 * Execute an operation with retry semantics. Operations should generally be
-	 * idempotent, but implementations may choose to implement compensation
-	 * semantics when an operation is retried.
-	 * @param context the current retry context.
-	 * @return the result of the successful operation.
-	 * @throws Exception if processing fails
-	 */
-	T  doWithRetry(RetryContext context) throws E;
+    /**
+     * Execute an operation with retry semantics. Operations should generally be
+     * idempotent, but implementations may choose to implement compensation
+     * semantics when an operation is retried.
+     * @param context the current retry context.
+     * @return the result of the successful operation.
+     * @throws Exception if processing fails
+     */
+    T doWithRetry(RetryContext context) throws E;
+
+    /**
+     * Allows to access information about method which is under retry
+     * @return MethodInvocation of the advised method
+     */
+    MethodInvocation getMethodInvocation();
 }

--- a/src/main/java/org/springframework/retry/interceptor/RetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/interceptor/RetryOperationsInterceptor.java
@@ -61,6 +61,11 @@ public class RetryOperationsInterceptor implements MethodInterceptor {
 
 		RetryCallback<Object, Throwable> retryCallback = new RetryCallback<Object, Throwable>() {
 
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return invocation;
+			}
+
 			public Object doWithRetry(RetryContext context) throws Exception {
 
 				/*

--- a/src/main/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptor.java
@@ -171,6 +171,11 @@ public class StatefulRetryOperationsInterceptor implements MethodInterceptor {
 				throw new IllegalStateException(e);
 			}
 		}
+
+		@Override
+		public MethodInvocation getMethodInvocation() {
+			return invocation;
+		}
 	}
 
 	/**

--- a/src/main/java/org/springframework/retry/support/RetrySimulator.java
+++ b/src/main/java/org/springframework/retry/support/RetrySimulator.java
@@ -19,6 +19,7 @@ package org.springframework.retry.support;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.aopalliance.intercept.MethodInvocation;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryPolicy;
@@ -99,6 +100,11 @@ public class RetrySimulator {
     static class FailingRetryCallback implements RetryCallback<Object, Exception> {
         public Object doWithRetry(RetryContext context) throws Exception {
             throw new FailingRetryException();
+        }
+
+        @Override
+        public MethodInvocation getMethodInvocation() {
+            return null;
         }
     }
 

--- a/src/test/java/org/springframework/retry/listener/RetryListenerTests.java
+++ b/src/test/java/org/springframework/retry/listener/RetryListenerTests.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.fail;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Test;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
@@ -58,6 +59,11 @@ public class RetryListenerTests {
 			public String doWithRetry(RetryContext context) throws Exception {
 				return null;
 			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return null;
+			}
 		});
 		assertEquals(2, count);
 		assertEquals(2, list.size());
@@ -76,6 +82,11 @@ public class RetryListenerTests {
 			template.execute(new RetryCallback<String, Exception>() {
 				public String doWithRetry(RetryContext context) throws Exception {
 					count++;
+					return null;
+				}
+
+				@Override
+				public MethodInvocation getMethodInvocation() {
 					return null;
 				}
 			});
@@ -106,6 +117,11 @@ public class RetryListenerTests {
 			public String doWithRetry(RetryContext context) throws Exception {
 				return null;
 			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return null;
+			}
 		});
 		assertEquals(2, count);
 		assertEquals(2, list.size());
@@ -130,6 +146,11 @@ public class RetryListenerTests {
 				public String doWithRetry(RetryContext context) throws Exception {
 					count++;
 					throw new IllegalStateException("foo");
+				}
+
+				@Override
+				public MethodInvocation getMethodInvocation() {
+					return null;
 				}
 			});
 			fail("Expected IllegalStateException");
@@ -158,6 +179,11 @@ public class RetryListenerTests {
 			public String doWithRetry(RetryContext context) throws Exception {
 				if (count++ < 1)
 					throw new RuntimeException("Retry!");
+				return null;
+			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
 				return null;
 			}
 		});

--- a/src/test/java/org/springframework/retry/policy/FatalExceptionRetryPolicyTests.java
+++ b/src/test/java/org/springframework/retry/policy/FatalExceptionRetryPolicyTests.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.fail;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Test;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryCallback;
@@ -110,6 +111,11 @@ public class FatalExceptionRetryPolicyTests {
 			this.attempts++;
 			// Just barf...
 			throw this.exceptionToThrow;
+		}
+
+		@Override
+		public MethodInvocation getMethodInvocation() {
+			return null;
 		}
 
 		public void setExceptionToThrow(Exception exceptionToThrow) {

--- a/src/test/java/org/springframework/retry/policy/StatefulRetryIntegrationTests.java
+++ b/src/test/java/org/springframework/retry/policy/StatefulRetryIntegrationTests.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Test;
 import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.retry.RecoveryCallback;
@@ -135,6 +136,11 @@ public class StatefulRetryIntegrationTests {
 						times.add(System.currentTimeMillis());
 						throw new Exception("Fail");
 					}
+
+					@Override
+					public MethodInvocation getMethodInvocation() {
+						return null;
+					}
 				}, new RecoveryCallback<String>() {
 					public String recover(RetryContext context)
 							throws Exception {
@@ -164,6 +170,11 @@ public class StatefulRetryIntegrationTests {
 				throw new RuntimeException();
 			}
 			return "bar";
+		}
+
+		@Override
+		public MethodInvocation getMethodInvocation() {
+			return null;
 		}
 	}
 

--- a/src/test/java/org/springframework/retry/support/RetrySynchronizationManagerTests.java
+++ b/src/test/java/org/springframework/retry/support/RetrySynchronizationManagerTests.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.retry.RetryCallback;
@@ -52,6 +53,11 @@ public class RetrySynchronizationManagerTests {
 				RetryContext global = RetrySynchronizationManager.getContext();
 				assertNotNull(status);
 				assertEquals(global, status);
+				return null;
+			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
 				return null;
 			}
 		});

--- a/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
+++ b/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.fail;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Test;
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.retry.ExhaustedRetryException;
@@ -84,6 +85,11 @@ public class RetryTemplateTests {
 						throw new IllegalArgumentException("Planned");
 					}
 					return "foo";
+				}
+
+				@Override
+				public MethodInvocation getMethodInvocation() {
+					return null;
 				}
 			};
 			RetryTemplate retryTemplate = new RetryTemplate();
@@ -230,6 +236,11 @@ public class RetryTemplateTests {
 					status.setExhaustedOnly();
 					throw new IllegalStateException("Retry this operation");
 				}
+
+				@Override
+				public MethodInvocation getMethodInvocation() {
+					return null;
+				}
 			});
 			fail("Expected ExhaustedRetryException");
 		} catch (ExhaustedRetryException ex) {
@@ -248,6 +259,11 @@ public class RetryTemplateTests {
 				public Object doWithRetry(RetryContext status) throws Exception {
 					status.setExhaustedOnly();
 					throw new IllegalStateException("Retry this operation");
+				}
+
+				@Override
+				public MethodInvocation getMethodInvocation() {
+					return null;
 				}
 			});
 			fail("Expected ExhaustedRetryException");
@@ -276,10 +292,20 @@ public class RetryTemplateTests {
 								RetrySynchronizationManager.getContext());
 						return null;
 					}
+
+					@Override
+					public MethodInvocation getMethodInvocation() {
+						return null;
+					}
 				});
 				assertSame("The context should be restored", status,
 						RetrySynchronizationManager.getContext());
 				return result;
+			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return null;
 			}
 		});
 		assertEquals(2, count);
@@ -293,6 +319,11 @@ public class RetryTemplateTests {
 			retryTemplate.execute(new RetryCallback<Object, Exception>() {
 				public Object doWithRetry(RetryContext context) throws Exception {
 					throw new Error("Realllly bad!");
+				}
+
+				@Override
+				public MethodInvocation getMethodInvocation() {
+					return null;
 				}
 			});
 			fail("Expected Error");
@@ -315,6 +346,11 @@ public class RetryTemplateTests {
 				public Object doWithRetry(RetryContext context) throws Exception {
 					throw new RuntimeException("Realllly bad!");
 				}
+
+				@Override
+				public MethodInvocation getMethodInvocation() {
+					return null;
+				}
 			});
 			fail("Expected Error");
 		} catch (TerminatedRetryException e) {
@@ -334,6 +370,11 @@ public class RetryTemplateTests {
 			retryTemplate.execute(new RetryCallback<Object, Exception>() {
 				public Object doWithRetry(RetryContext context) throws Exception {
 					throw new RuntimeException("Bad!");
+				}
+
+				@Override
+				public MethodInvocation getMethodInvocation() {
+					return null;
 				}
 			});
 			fail("Expected RuntimeException");
@@ -368,6 +409,11 @@ public class RetryTemplateTests {
 					throw new Exception("maybe next time!");
 				}
 
+				@Override
+				public MethodInvocation getMethodInvocation() {
+					return null;
+				}
+
 			}, null, new DefaultRetryState(tested) {
 
 				@Override
@@ -397,6 +443,11 @@ public class RetryTemplateTests {
 			if (attempts < attemptsBeforeSuccess) {
 				throw this.exceptionToThrow;
 			}
+			return null;
+		}
+
+		@Override
+		public MethodInvocation getMethodInvocation() {
 			return null;
 		}
 

--- a/src/test/java/org/springframework/retry/support/StatefulRecoveryRetryTests.java
+++ b/src/test/java/org/springframework/retry/support/StatefulRecoveryRetryTests.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
+import org.aopalliance.intercept.MethodInvocation;
 import org.junit.Test;
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.dao.DataAccessException;
@@ -90,6 +91,11 @@ public class StatefulRecoveryRetryTests {
 			public String doWithRetry(RetryContext context) throws Exception {
 				throw new RuntimeException("Barf!");
 			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return null;
+			}
 		};
 		RecoveryCallback<String> recoveryCallback = new RecoveryCallback<String>() {
 			public String recover(RetryContext context) {
@@ -128,6 +134,11 @@ public class StatefulRecoveryRetryTests {
 			public String doWithRetry(RetryContext context) throws Exception {
 				throw new RuntimeException("Barf!");
 			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return null;
+			}
 		};
 		RecoveryCallback<String> recoveryCallback = new RecoveryCallback<String>() {
 			public String recover(RetryContext context) {
@@ -155,6 +166,11 @@ public class StatefulRecoveryRetryTests {
 		RetryCallback<String, Exception> callback = new RetryCallback<String, Exception>() {
 			public String doWithRetry(RetryContext context) throws Exception {
 				throw new RuntimeException("Barf!");
+			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return null;
 			}
 		};
 
@@ -196,6 +212,11 @@ public class StatefulRecoveryRetryTests {
 				((StringHolder) item).string = ((StringHolder) item).string + (count++);
 				throw new RuntimeException("Barf!");
 			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return null;
+			}
 		};
 
 		try {
@@ -236,6 +257,11 @@ public class StatefulRecoveryRetryTests {
 				count++;
 				throw new RuntimeException("Barf!");
 			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return null;
+			}
 		};
 
 		try {
@@ -270,6 +296,11 @@ public class StatefulRecoveryRetryTests {
 			public Object doWithRetry(RetryContext context) throws Exception {
 				count++;
 				throw new RuntimeException("Barf!");
+			}
+
+			@Override
+			public MethodInvocation getMethodInvocation() {
+				return null;
 			}
 		};
 		RecoveryCallback<Object> recoveryCallback = new RecoveryCallback<Object>() {


### PR DESCRIPTION
I would like to have some monitoring on amount of retries happened. Looks like RetryListener is right place to start, but I do want to have at least method name which fails under retry. Updated RetryContext to have this info.