### PR TITLE
Fix wrong javadoc

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/CircuitBreaker.java
+++ b/src/main/java/org/springframework/retry/annotation/CircuitBreaker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2016 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  *
  * @author Dave Syer
  * @author Artem Bilan
- * @since 1.1
+ * @since 1.2
  *
  */
 @Target({ ElementType.METHOD, ElementType.TYPE })


### PR DESCRIPTION
`@CircuitBreaker` is introduced since not 1.1 but 1.2
