### PR TITLE
Drop use of Log4J 1.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,13 +260,6 @@
 			<artifactId>spring-tx</artifactId>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>log4j</groupId>
-			<artifactId>log4j</artifactId>
-			<version>1.2.14</version>
-			<optional>true</optional>
-			<scope>runtime</scope>
-		</dependency>
 	</dependencies>
 
 	<reporting>

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,8 +1,0 @@
-log4j.rootCategory=INFO, stdout
-
-log4j.appender.stdout=org.apache.log4j.ConsoleAppender
-log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
-log4j.appender.stdout.layout.ConversionPattern=%d %p [%c] - <%m>%n
-
-log4j.category.org.springframework.transaction=INFO
-#log4j.category.org.springframework.retry=TRACE


### PR DESCRIPTION
Given that it was declared EOL in August 2015, it'd be nice to drop the use of Log4J 1.2. It's currently an optional runtime dependency and the project seems to build cleanly (`./mvnw clean package`) without it, so perhaps it's already been dropped in all but the pom?