### PR TITLE
 Calling getMaxAttempts instead of maxAttempts

### DIFF
--- a/src/main/java/org/springframework/retry/policy/SimpleRetryPolicy.java
+++ b/src/main/java/org/springframework/retry/policy/SimpleRetryPolicy.java
@@ -140,7 +140,7 @@ public class SimpleRetryPolicy implements RetryPolicy {
 	@Override
 	public boolean canRetry(RetryContext context) {
 		Throwable t = context.getLastThrowable();
-		return (t == null || retryForException(t)) && context.getRetryCount() < maxAttempts;
+		return (t == null || retryForException(t)) && context.getRetryCount() < getMaxAttempts();
 	}
 
 	/**


### PR DESCRIPTION
This is done to support maxAttempts to be configurable at Tenant level in a Multi Tenant Application. In this case, one can simple override getMaxAttempts and return appropriate value based on Context Tenant.