### PR TITLE
Allow resetTimeout and openTimeout to be inject via properties

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -228,6 +228,20 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 			CircuitBreakerRetryPolicy breaker = new CircuitBreakerRetryPolicy(policy);
 			breaker.setOpenTimeout(circuit.openTimeout());
 			breaker.setResetTimeout(circuit.resetTimeout());
+            if (StringUtils.hasText(circuit.resetTimeoutString())) {
+                try {
+                    breaker.setResetTimeout(Long.parseLong(circuit.resetTimeoutString()));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException(String.format("Invalid resetTimeoutString value %s - cannot parse into long", circuit.resetTimeoutString()));
+                }
+            }
+            if (StringUtils.hasText(circuit.openTimeoutString())) {
+                try {
+                    breaker.setOpenTimeout(Long.parseLong(circuit.openTimeoutString()));
+                } catch (NumberFormatException e) {
+                    throw new IllegalArgumentException(String.format("Invalid openTimeoutString value %s - cannot parse into long", circuit.openTimeoutString()));
+                }
+            }
 			template.setRetryPolicy(breaker);
 			template.setBackOffPolicy(new NoBackOffPolicy());
 			String label = circuit.label();

--- a/src/main/java/org/springframework/retry/annotation/CircuitBreaker.java
+++ b/src/main/java/org/springframework/retry/annotation/CircuitBreaker.java
@@ -80,6 +80,14 @@ public @interface CircuitBreaker {
 	long resetTimeout() default 20000;
 
 	/**
+	 * If the circuit is open for longer than this timeout then it resets on the next call
+	 * to give the downstream component a chance to respond again.
+	 *
+	 * @return the timeout before an open circuit is reset in milliseconds as a String value
+	 */
+	String resetTimeoutString() default "";
+
+	/**
 	 * When {@link #maxAttempts()} failures are reached within this timeout, the circuit
 	 * is opened automatically, preventing access to the downstream component.
 	 *
@@ -87,5 +95,13 @@ public @interface CircuitBreaker {
 	 * 5000
 	 */
 	long openTimeout() default 5000;
+
+	/**
+	 * When {@link #maxAttempts()} failures are reached within this timeout, the circuit
+	 * is opened automatically, preventing access to the downstream component.
+	 *
+	 * @return the timeout before an closed circuit is opened in milliseconds as a String value
+	 */
+	String openTimeoutString() default "";
 
 }

--- a/src/test/java/org/springframework/retry/annotation/CircuitBreakerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/CircuitBreakerTests.java
@@ -92,7 +92,7 @@ public class CircuitBreakerTests {
 
 		private RetryContext context;
 
-		@CircuitBreaker(RuntimeException.class)
+		@CircuitBreaker(value = RuntimeException.class, openTimeoutString = "5000", resetTimeoutString = "20000")
 		public void service() {
 			this.context = RetrySynchronizationManager.getContext();
 			if (this.count++ < 5) {


### PR DESCRIPTION
We cannot inject the openTimeout and resetTimeout via application properties. This commit is to enable this.