### PR TITLE
Locate matching @Recover based on the number of parameters

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
+++ b/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
@@ -16,16 +16,16 @@
 
 package org.springframework.retry.annotation;
 
+import java.lang.reflect.Method;
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.classify.SubclassClassifier;
 import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.retry.interceptor.MethodInvocationRecoverer;
 import org.springframework.util.ReflectionUtils;
 import org.springframework.util.ReflectionUtils.MethodCallback;
-
-import java.lang.reflect.Method;
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * A recoverer for method invocations based on the <code>@Recover</code> annotation. A
@@ -121,7 +121,11 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 				startingIndex = 1;
 			}
 			for (int i = startingIndex; i < parameterTypes.length; i++) {
-				if (parameterTypes[i] != args[i-1].getClass()) {
+				final Object argument = args[i-1];
+				if (argument == null) {
+					continue;
+				}
+				if (parameterTypes[i] != argument.getClass()) {
 					return false;
 				}
 			}

--- a/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
@@ -22,9 +22,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.springframework.retry.ExhaustedRetryException;
-import org.springframework.retry.annotation.Recover;
-import org.springframework.retry.annotation.RecoverAnnotationRecoveryHandler;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.util.ReflectionUtils;
 
 import java.lang.reflect.Method;
@@ -32,6 +29,7 @@ import java.lang.reflect.Method;
 /**
  * @author Dave Syer
  * @author Aldo Sinanaj
+ * @author Randell Callahan
  */
 public class RecoverAnnotationRecoveryHandlerTests {
 
@@ -113,6 +111,28 @@ public class RecoverAnnotationRecoveryHandlerTests {
 				"bar", String.class));
 		assertEquals(3,
 				barHandler.recover(new Object[] { "Aldo" }, new RuntimeException("Planned")));
+
+	}
+
+	@Test
+	public void multipleQualifyingRecoverMethods (){
+		Method foo = ReflectionUtils.findMethod(MultipleQualifyingRecovers.class,
+				"foo", String.class);
+		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
+				new MultipleQualifyingRecovers(), foo);
+		assertEquals(1,
+				handler.recover(new Object[] { "Randell" }, new RuntimeException("Planned")));
+
+	}
+
+	@Test
+	public void multipleQualifyingRecoverMethodsReOrdered (){
+		Method foo = ReflectionUtils.findMethod(MultipleQualifyingRecoversReOrdered.class,
+				"foo", String.class);
+		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
+				new MultipleQualifyingRecoversReOrdered(), foo);
+		assertEquals(3,
+				handler.recover(new Object[] { "Randell" }, new RuntimeException("Planned")));
 
 	}
 
@@ -227,6 +247,54 @@ public class RecoverAnnotationRecoveryHandlerTests {
 
 		@Recover
 		public Number quux(RuntimeException re, String name) {
+			return 3;
+		}
+
+	}
+
+	protected static class MultipleQualifyingRecovers {
+
+		@Retryable
+		public int foo(String name) {
+			return 0;
+		}
+
+		@Recover
+		public int fooRecover(Throwable e, String name) {
+			return 1;
+		}
+
+		@Recover
+		public int fooRecover(Throwable e) {
+			return 2;
+		}
+
+		@Recover
+		public int barRecover(Throwable e, int number) {
+			return 3;
+		}
+
+	}
+
+	protected static class MultipleQualifyingRecoversReOrdered {
+
+		@Retryable
+		public int foo(String name) {
+			return 0;
+		}
+
+		@Recover
+		public int fooRecover(Throwable e) {
+			return 1;
+		}
+
+		@Recover
+		public int barRecover(Throwable e, int number) {
+			return 2;
+		}
+
+		@Recover
+		public int fooRecover(Throwable e, String name) {
 			return 3;
 		}
 

--- a/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
@@ -115,7 +115,7 @@ public class RecoverAnnotationRecoveryHandlerTests {
 	}
 
 	@Test
-	public void multipleQualifyingRecoverMethods (){
+	public void multipleQualifyingRecoverMethods(){
 		Method foo = ReflectionUtils.findMethod(MultipleQualifyingRecovers.class,
 				"foo", String.class);
 		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
@@ -126,7 +126,18 @@ public class RecoverAnnotationRecoveryHandlerTests {
 	}
 
 	@Test
-	public void multipleQualifyingRecoverMethodsReOrdered (){
+	public void multipleQualifyingRecoverMethodsWithNull(){
+		Method foo = ReflectionUtils.findMethod(MultipleQualifyingRecovers.class,
+				"foo", String.class);
+		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
+				new MultipleQualifyingRecovers(), foo);
+		assertEquals(1,
+				handler.recover(new Object[] { null }, new RuntimeException("Planned")));
+
+	}
+
+	@Test
+	public void multipleQualifyingRecoverMethodsReOrdered(){
 		Method foo = ReflectionUtils.findMethod(MultipleQualifyingRecoversReOrdered.class,
 				"foo", String.class);
 		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(


### PR DESCRIPTION
Related to https://github.com/spring-projects/spring-retry/issues/85

When locating the closest `@Recover` method and there are multiple matching `@Recover` methods, choose the `@Recover` method that matches based on the number of parameters and the types of the parameters (to avoid `java.lang.IllegalArgumentException: argument type mismatch`)