### PR TITLE
URL Cleanup

### DIFF
--- a/mvnw
+++ b/mvnw
@@ -8,7 +8,7 @@
 # "License"); you may not use this file except in compliance
 # with the License.  You may obtain a copy of the License at
 #
-#    http://www.apache.org/licenses/LICENSE-2.0
+#    https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing,
 # software distributed under the License is distributed on an

--- a/mvnw.cmd
+++ b/mvnw.cmd
@@ -7,7 +7,7 @@
 @REM "License"); you may not use this file except in compliance
 @REM with the License.  You may obtain a copy of the License at
 @REM
-@REM    http://www.apache.org/licenses/LICENSE-2.0
+@REM    https://www.apache.org/licenses/LICENSE-2.0
 @REM
 @REM Unless required by applicable law or agreed to in writing,
 @REM software distributed under the License is distributed on an

--- a/pom.xml
+++ b/pom.xml
@@ -8,15 +8,15 @@
 	<name>Spring Retry</name>
 	<description><![CDATA[Spring Retry provides an abstraction around retrying failed operations, with an emphasis on declarative control of the process and policy-based bahaviour that is easy to extend and customize.  For instance, you can configure a plain POJO operation to retry if it fails, based on the type of exception, and with a fixed or exponential backoff.
     ]]></description>
-	<url>http://www.springsource.org</url>
+	<url>https://www.springsource.org</url>
 	<organization>
 		<name>SpringSource</name>
-		<url>http://www.springsource.com</url>
+		<url>https://www.springsource.com</url>
 	</organization>
 	<licenses>
 		<license>
 			<name>Apache 2.0</name>
-			<url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+			<url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
 		</license>
 	</licenses>
 	<packaging>jar</packaging>
@@ -163,7 +163,7 @@
 	</profiles>
 
 	<scm>
-		<url>http://github.com/spring-projects/spring-retry</url>
+		<url>https://github.com/spring-projects/spring-retry</url>
 		<connection>scm:git:git://github.com/spring-projects/spring-retry.git</connection>
 		<developerConnection>scm:git:ssh://git@github.com/spring-projects/spring-retry.git</developerConnection>
 		<tag>HEAD</tag>
@@ -179,7 +179,7 @@
 
 	<distributionManagement>
 		<!-- see 'staging' profile for dry-run deployment settings -->
-		<downloadUrl>http://www.springsource.com/download/community
+		<downloadUrl>https://www.springsource.com/download/community
 		</downloadUrl>
 		<site>
 			<id>spring-docs</id>


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were fixed successfully.

* http://github.com/spring-projects/spring-retry migrated to:  
  https://github.com/spring-projects/spring-retry ([https](https://github.com/spring-projects/spring-retry) result 200).
* http://www.apache.org/licenses/LICENSE-2.0 migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).
* http://www.apache.org/licenses/LICENSE-2.0.txt migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0.txt ([https](https://www.apache.org/licenses/LICENSE-2.0.txt) result 200).
* http://www.springsource.com migrated to:  
  https://www.springsource.com ([https](https://www.springsource.com) result 301).
* http://www.springsource.org migrated to:  
  https://www.springsource.org ([https](https://www.springsource.org) result 301).
* http://www.springsource.com/download/community migrated to:  
  https://www.springsource.com/download/community ([https](https://www.springsource.com/download/community) result 302).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0
* http://maven.apache.org/maven-v4_0_0.xsd
* http://www.w3.org/2001/XMLSchema-instance