### PR TITLE
URL Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.retry</groupId>
 	<artifactId>spring-retry</artifactId>

--- a/src/test/resources/org/springframework/retry/interceptor/retry-transaction-test.xml
+++ b/src/test/resources/org/springframework/retry/interceptor/retry-transaction-test.xml
@@ -5,9 +5,9 @@
 	xmlns:p="http://www.springframework.org/schema/p"
 	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="
-		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-2.0.xsd
-		http://www.springframework.org/schema/aop http://www.springframework.org/schema/aop/spring-aop-2.0.xsd
-		http://www.springframework.org/schema/tx http://www.springframework.org/schema/tx/spring-tx-2.0.xsd">
+		http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans-2.0.xsd
+		http://www.springframework.org/schema/aop https://www.springframework.org/schema/aop/spring-aop-2.0.xsd
+		http://www.springframework.org/schema/tx https://www.springframework.org/schema/tx/spring-tx-2.0.xsd">
 
 	<aop:config>
 		<aop:pointcut id="transactional"


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* http://www.springframework.org/schema/aop/spring-aop-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/aop/spring-aop-2.0.xsd ([https](https://www.springframework.org/schema/aop/spring-aop-2.0.xsd) result 200).
* http://www.springframework.org/schema/beans/spring-beans-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/beans/spring-beans-2.0.xsd ([https](https://www.springframework.org/schema/beans/spring-beans-2.0.xsd) result 200).
* http://www.springframework.org/schema/tx/spring-tx-2.0.xsd with 1 occurrences migrated to:  
  https://www.springframework.org/schema/tx/spring-tx-2.0.xsd ([https](https://www.springframework.org/schema/tx/spring-tx-2.0.xsd) result 200).
* http://maven.apache.org/maven-v4_0_0.xsd with 1 occurrences migrated to:  
  https://maven.apache.org/maven-v4_0_0.xsd ([https](https://maven.apache.org/maven-v4_0_0.xsd) result 301).

# Ignored
These URLs were intentionally ignored.

* http://maven.apache.org/POM/4.0.0 with 2 occurrences
* http://www.springframework.org/schema/aop with 2 occurrences
* http://www.springframework.org/schema/beans with 2 occurrences
* http://www.springframework.org/schema/p with 1 occurrences
* http://www.springframework.org/schema/tx with 2 occurrences
* http://www.w3.org/2001/XMLSchema-instance with 2 occurrences