### PR TITLE
Expose the MethodInvocation in the MethodInvocationRetryCallback 

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,13 +218,10 @@ Note that when there is more than one listener, they are in a list, so there is 
 
 ### Listeners for reflective method invocations
 
-When dealing with methods annotated with `@Retryable` or with Spring AOP intercepted methods,
-spring-retry provides the possibility to inspect in detail the method invocation within the
-`RetryListener` implementation. Such a scenario could be particularly useful when there is a need
-to monitor how often a certain method call has been retried and expose it with detailed tagging
-information (e.g. : class name, method name, or even parameter values in some exotic cases).
+When dealing with methods annotated with `@Retryable` or with Spring AOP intercepted methods, spring-retry provides the possibility to inspect in detail the method invocation within the `RetryListener` implementation.
 
-All that needs to be done is checking whe
+Such a scenario could be particularly useful when there is a need to monitor how often a certain method call has been retried and expose it with detailed tagging information (e.g. : class name, method name, or even parameter values in some exotic cases).
+
 
 ```java
 

--- a/pom.xml
+++ b/pom.xml
@@ -219,12 +219,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.hamcrest</groupId>
-			<artifactId>hamcrest-all</artifactId>
-			<version>1.3</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>org.easymock</groupId>
 			<artifactId>easymock</artifactId>
 			<version>2.3</version>

--- a/pom.xml
+++ b/pom.xml
@@ -219,6 +219,12 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-all</artifactId>
+			<version>1.3</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.easymock</groupId>
 			<artifactId>easymock</artifactId>
 			<version>2.3</version>

--- a/src/main/java/org/springframework/retry/interceptor/MethodInvocationRetryCallback.java
+++ b/src/main/java/org/springframework/retry/interceptor/MethodInvocationRetryCallback.java
@@ -1,0 +1,53 @@
+package org.springframework.retry.interceptor;
+
+import org.aopalliance.intercept.MethodInvocation;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryOperations;
+import org.springframework.util.StringUtils;
+
+/**
+ * Callback class for a Spring AOP reflective `MethodInvocation` that can be retried using a {@link
+ * RetryOperations}.
+ *
+ * In a concrete {@link org.springframework.retry.RetryListener} implementation, the
+ * `MethodInvocation` can be analysed for providing insights on the method called as well as its
+ * parameter values which could then be used for monitoring purposes.
+ *
+ * @param <T> the type of object returned by the callback
+ * @param <E> the type of exception it declares may be thrown
+ * @see StatefulRetryOperationsInterceptor
+ * @see RetryOperationsInterceptor
+ * @see org.springframework.retry.listener.MethodInvocationRetryListenerSupport
+ * @since 1.3
+ */
+public abstract class MethodInvocationRetryCallback<T, E extends Throwable>
+		implements RetryCallback<T, E> {
+
+	protected final MethodInvocation invocation;
+
+	protected final String label;
+
+	/**
+	 * Constructor for the class.
+	 *
+	 * @param invocation the method invocation
+	 * @param label a unique label for statistics reporting.
+	 */
+	public MethodInvocationRetryCallback(MethodInvocation invocation, String label) {
+		this.invocation = invocation;
+		if (StringUtils.hasText(label)) {
+			this.label = label;
+		} else {
+			this.label = invocation.getMethod().toGenericString();
+		}
+	}
+
+	public MethodInvocation getInvocation() {
+		return invocation;
+	}
+
+	public String getLabel() {
+		return label;
+	}
+
+}

--- a/src/main/java/org/springframework/retry/interceptor/MethodInvocationRetryCallback.java
+++ b/src/main/java/org/springframework/retry/interceptor/MethodInvocationRetryCallback.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2006-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package org.springframework.retry.interceptor;
 
 import org.aopalliance.intercept.MethodInvocation;
@@ -6,18 +22,19 @@ import org.springframework.retry.RetryOperations;
 import org.springframework.util.StringUtils;
 
 /**
- * Callback class for a Spring AOP reflective `MethodInvocation` that can be retried using a {@link
- * RetryOperations}.
+ * Callback class for a Spring AOP reflective `MethodInvocation` that can be retried using
+ * a {@link RetryOperations}.
  *
  * In a concrete {@link org.springframework.retry.RetryListener} implementation, the
- * `MethodInvocation` can be analysed for providing insights on the method called as well as its
- * parameter values which could then be used for monitoring purposes.
+ * `MethodInvocation` can be analysed for providing insights on the method called as well
+ * as its parameter values which could then be used for monitoring purposes.
  *
  * @param <T> the type of object returned by the callback
  * @param <E> the type of exception it declares may be thrown
  * @see StatefulRetryOperationsInterceptor
  * @see RetryOperationsInterceptor
  * @see org.springframework.retry.listener.MethodInvocationRetryListenerSupport
+ * @author Marius Grama
  * @since 1.3
  */
 public abstract class MethodInvocationRetryCallback<T, E extends Throwable>
@@ -29,7 +46,6 @@ public abstract class MethodInvocationRetryCallback<T, E extends Throwable>
 
 	/**
 	 * Constructor for the class.
-	 *
 	 * @param invocation the method invocation
 	 * @param label a unique label for statistics reporting.
 	 */
@@ -37,7 +53,8 @@ public abstract class MethodInvocationRetryCallback<T, E extends Throwable>
 		this.invocation = invocation;
 		if (StringUtils.hasText(label)) {
 			this.label = label;
-		} else {
+		}
+		else {
 			this.label = invocation.getMethod().toGenericString();
 		}
 	}

--- a/src/main/java/org/springframework/retry/interceptor/RetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/interceptor/RetryOperationsInterceptor.java
@@ -75,7 +75,8 @@ public class RetryOperationsInterceptor implements MethodInterceptor {
 		}
 		final String label = name;
 
-		RetryCallback<Object, Throwable> retryCallback = new RetryCallback<Object, Throwable>() {
+		RetryCallback<Object, Throwable> retryCallback = new MethodInvocationRetryCallback<Object, Throwable>(
+				invocation, label) {
 
 			public Object doWithRetry(RetryContext context) throws Exception {
 

--- a/src/main/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2016 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptor.java
@@ -168,7 +168,7 @@ public class StatefulRetryOperationsInterceptor implements MethodInterceptor {
 				this.rollbackClassifier);
 
 		Object result = this.retryOperations
-				.execute(new MethodInvocationRetryCallback(invocation, label),
+				.execute(new StatefulMethodInvocationRetryCallback(invocation, label),
 						this.recoverer != null
 								? new ItemRecovererCallback(args, this.recoverer) : null,
 						retryState);
@@ -204,21 +204,12 @@ public class StatefulRetryOperationsInterceptor implements MethodInterceptor {
 	 * @author Dave Syer
 	 *
 	 */
-	private static final class MethodInvocationRetryCallback
-			implements RetryCallback<Object, Throwable> {
+	private static final class StatefulMethodInvocationRetryCallback
+			extends MethodInvocationRetryCallback<Object, Throwable> {
 
-		private final MethodInvocation invocation;
-
-		private String label;
-
-		private MethodInvocationRetryCallback(MethodInvocation invocation, String label) {
-			this.invocation = invocation;
-			if (StringUtils.hasText(label)) {
-				this.label = label;
-			}
-			else {
-				this.label = invocation.getMethod().toGenericString();
-			}
+		private StatefulMethodInvocationRetryCallback(MethodInvocation invocation,
+				String label) {
+			super(invocation, label);
 		}
 
 		@Override

--- a/src/main/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupport.java
+++ b/src/main/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -30,6 +30,7 @@ import org.springframework.retry.interceptor.MethodInvocationRetryCallback;
  * NOTE that this listener performs an action only when dealing with callbacks that are
  * instances of {@link MethodInvocationRetryCallback}.
  *
+ * @author Marius Grama
  * @since 1.3
  */
 public class MethodInvocationRetryListenerSupport implements RetryListener {

--- a/src/main/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupport.java
+++ b/src/main/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupport.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2006-2007 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.listener;
+
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
+import org.springframework.retry.interceptor.MethodInvocationRetryCallback;
+
+/**
+ * <p>
+ * Empty method implementation of {@link RetryListener} with focus on the AOP reflective
+ * method invocations providing convenience retry listener type-safe (with a
+ * `MethodInvocationRetryCallback` callback parameter) specific methods.
+ * </p>
+ * NOTE that this listener performs an action only when dealing with callbacks that are
+ * instances of {@link MethodInvocationRetryCallback}.
+ *
+ * @since 1.3
+ */
+public class MethodInvocationRetryListenerSupport implements RetryListener {
+
+	public <T, E extends Throwable> void close(RetryContext context,
+			RetryCallback<T, E> callback, Throwable throwable) {
+		if (callback instanceof MethodInvocationRetryCallback) {
+			MethodInvocationRetryCallback<T, E> methodInvocationRetryCallback = (MethodInvocationRetryCallback<T, E>) callback;
+			doClose(context, methodInvocationRetryCallback, throwable);
+		}
+	}
+
+	public <T, E extends Throwable> void onError(RetryContext context,
+			RetryCallback<T, E> callback, Throwable throwable) {
+		if (callback instanceof MethodInvocationRetryCallback) {
+			MethodInvocationRetryCallback<T, E> methodInvocationRetryCallback = (MethodInvocationRetryCallback<T, E>) callback;
+			doOnError(context, methodInvocationRetryCallback, throwable);
+		}
+	}
+
+	public <T, E extends Throwable> boolean open(RetryContext context,
+			RetryCallback<T, E> callback) {
+		if (callback instanceof MethodInvocationRetryCallback) {
+			MethodInvocationRetryCallback<T, E> methodInvocationRetryCallback = (MethodInvocationRetryCallback<T, E>) callback;
+			return doOpen(context, methodInvocationRetryCallback);
+		}
+		// in case that the callback is not for a reflective method invocation
+		// just go forward with the execution
+		return true;
+	}
+
+	protected <T, E extends Throwable> void doClose(RetryContext context,
+			MethodInvocationRetryCallback<T, E> callback, Throwable throwable) {
+	}
+
+	protected <T, E extends Throwable> void doOnError(RetryContext context,
+			MethodInvocationRetryCallback<T, E> callback, Throwable throwable) {
+	}
+
+	protected <T, E extends Throwable> boolean doOpen(RetryContext context,
+			MethodInvocationRetryCallback<T, E> callback) {
+		return true;
+	}
+
+}

--- a/src/main/java/org/springframework/retry/support/RetryTemplateBuilder.java
+++ b/src/main/java/org/springframework/retry/support/RetryTemplateBuilder.java
@@ -40,8 +40,7 @@ import org.springframework.util.Assert;
  * builder method - see it's doc.
  *
  * <p>
- * Examples:
- * <pre>{@code
+ * Examples: <pre>{@code
  * RetryTemplate.builder()
  *      .maxAttempts(10)
  *      .exponentialBackoff(100, 2, 10000)
@@ -83,7 +82,6 @@ import org.springframework.util.Assert;
  *
  * @author Aleksandr Shamukov
  * @author Artem Bilan
- *
  * @since 1.3
  */
 public class RetryTemplateBuilder {

--- a/src/test/java/org/springframework/retry/annotation/CircuitBreakerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/CircuitBreakerTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2015-2018 the original author or authors.
+ * Copyright 2015-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -130,7 +130,10 @@ public class CircuitBreakerTests {
 			}
 		}
 
-		@CircuitBreaker(maxAttemptsExpression = "#{2 * ${foo:4}}", openTimeoutExpression = "#{${bar:19}000}", resetTimeoutExpression = "#{${baz:20}000}", exceptionExpression = "#{#root instanceof RuntimeExpression}")
+		@CircuitBreaker(maxAttemptsExpression = "#{2 * ${foo:4}}",
+				openTimeoutExpression = "#{${bar:19}000}",
+				resetTimeoutExpression = "#{${baz:20}000}",
+				exceptionExpression = "#{#root instanceof RuntimeExpression}")
 		public void expressionService() {
 			this.count++;
 		}

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
@@ -458,7 +458,8 @@ public class EnableRetryTests {
 
 		private int count = 0;
 
-		@Retryable(include = RuntimeException.class, exclude = IllegalStateException.class)
+		@Retryable(include = RuntimeException.class,
+				exclude = IllegalStateException.class)
 		public void service() {
 			if (count++ < 2) {
 				throw new IllegalStateException("Planned");
@@ -545,7 +546,11 @@ public class EnableRetryTests {
 			throw new RuntimeException("this cannot be retried");
 		}
 
-		@Retryable(exceptionExpression = "#{@exceptionChecker.${retryMethod}(#root)}", maxAttemptsExpression = "#{@integerFiveBean}", backoff = @Backoff(delayExpression = "#{${one}}", maxDelayExpression = "#{${five}}", multiplierExpression = "#{${onePointOne}}"))
+		@Retryable(exceptionExpression = "#{@exceptionChecker.${retryMethod}(#root)}",
+				maxAttemptsExpression = "#{@integerFiveBean}",
+				backoff = @Backoff(delayExpression = "#{${one}}",
+						maxDelayExpression = "#{${five}}",
+						multiplierExpression = "#{${onePointOne}}"))
 		public void service3() {
 			if (count++ < 8) {
 				throw new RuntimeException();
@@ -559,7 +564,8 @@ public class EnableRetryTests {
 			}
 		}
 
-		@Retryable(exceptionExpression = "message.contains('this can be retried')", include = RuntimeException.class)
+		@Retryable(exceptionExpression = "message.contains('this can be retried')",
+				include = RuntimeException.class)
 		public void service5() {
 			if (count++ < 11) {
 				throw new RuntimeException("this can be retried");

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryWithBackoffTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryWithBackoffTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -192,7 +192,8 @@ public class EnableRetryWithBackoffTests {
 
 		private int count = 0;
 
-		@Retryable(backoff = @Backoff(delay = 1000, maxDelay = 2000, multiplier = 1.1, random = true))
+		@Retryable(backoff = @Backoff(delay = 1000, maxDelay = 2000, multiplier = 1.1,
+				random = true))
 		public void service(int value) {
 			if (count++ < 2) {
 				throw new RuntimeException("Planned");

--- a/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -15,14 +15,6 @@
  */
 
 package org.springframework.retry.interceptor;
-
-import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.hamcrest.core.AllOf.allOf;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
 
 import java.lang.reflect.AccessibleObject;
 import java.lang.reflect.Method;
@@ -48,6 +40,13 @@ import org.springframework.retry.support.RetryTemplate;
 import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.util.ClassUtils;
+
+import static org.hamcrest.core.IsEqual.equalTo;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 public class RetryOperationsInterceptorTests {
 
@@ -128,10 +127,10 @@ public class RetryOperationsInterceptorTests {
 		this.service.service();
 		assertEquals(2, count);
 		assertEquals(3, monitoringTags.entrySet().size());
-		assertThat(monitoringTags, allOf(hasEntry(labelTagName, label),
-				hasEntry(classTagName,
-						RetryOperationsInterceptorTests.Service.class.getSimpleName()),
-				hasEntry(methodTagName, "service")));
+		assertThat(monitoringTags.get(labelTagName), equalTo(label));
+		assertThat(monitoringTags.get(classTagName),
+				equalTo(RetryOperationsInterceptorTests.Service.class.getSimpleName()));
+		assertThat(monitoringTags.get(methodTagName), equalTo("service"));
 	}
 
 	@Test

--- a/src/test/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupportTests.java
+++ b/src/test/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupportTests.java
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2006-2007 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.listener;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.junit.Test;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.interceptor.MethodInvocationRetryCallback;
+
+public class MethodInvocationRetryListenerSupportTests {
+
+	@Test
+	public void testClose() {
+		MethodInvocationRetryListenerSupport support = new MethodInvocationRetryListenerSupport();
+		try {
+			support.close(null, null, null);
+		}
+		catch (Exception e) {
+			fail("Unexpected exception");
+		}
+	}
+
+	@Test
+	public void testCloseWithMethodInvocationRetryCallbackShouldCallDoCloseMethod() {
+		final AtomicInteger callsOnDoCloseMethod = new AtomicInteger(0);
+		MethodInvocationRetryListenerSupport support = new MethodInvocationRetryListenerSupport() {
+			@Override
+			protected <T, E extends Throwable> void doClose(RetryContext context,
+					MethodInvocationRetryCallback<T, E> callback, Throwable throwable) {
+				callsOnDoCloseMethod.incrementAndGet();
+			}
+		};
+		RetryContext context = mock(RetryContext.class);
+		MethodInvocationRetryCallback callback = mock(
+				MethodInvocationRetryCallback.class);
+		support.close(context, callback, null);
+
+		assertEquals(1, callsOnDoCloseMethod.get());
+	}
+
+	@Test
+	public void testCloseWithRetryCallbackShouldntCallDoCloseMethod() {
+		final AtomicInteger callsOnDoCloseMethod = new AtomicInteger(0);
+		MethodInvocationRetryListenerSupport support = new MethodInvocationRetryListenerSupport() {
+			@Override
+			protected <T, E extends Throwable> void doClose(RetryContext context,
+					MethodInvocationRetryCallback<T, E> callback, Throwable throwable) {
+				callsOnDoCloseMethod.incrementAndGet();
+			}
+		};
+		RetryContext context = mock(RetryContext.class);
+		RetryCallback callback = mock(RetryCallback.class);
+		support.close(context, callback, null);
+
+		assertEquals(0, callsOnDoCloseMethod.get());
+	}
+
+	@Test
+	public void testOnError() {
+		MethodInvocationRetryListenerSupport support = new MethodInvocationRetryListenerSupport();
+		try {
+			support.onError(null, null, null);
+		}
+		catch (Exception e) {
+			fail("Unexpected exception");
+		}
+	}
+
+	@Test
+	public void testOnErrorWithMethodInvocationRetryCallbackShouldCallDoOnErrorMethod() {
+		final AtomicInteger callsOnDoOnErrorMethod = new AtomicInteger(0);
+		MethodInvocationRetryListenerSupport support = new MethodInvocationRetryListenerSupport() {
+			@Override
+			protected <T, E extends Throwable> void doOnError(RetryContext context,
+					MethodInvocationRetryCallback<T, E> callback, Throwable throwable) {
+				callsOnDoOnErrorMethod.incrementAndGet();
+			}
+		};
+		RetryContext context = mock(RetryContext.class);
+		MethodInvocationRetryCallback callback = mock(
+				MethodInvocationRetryCallback.class);
+		support.onError(context, callback, null);
+
+		assertEquals(1, callsOnDoOnErrorMethod.get());
+	}
+
+	@Test
+	public void testOpen() {
+		MethodInvocationRetryListenerSupport support = new MethodInvocationRetryListenerSupport();
+		assertTrue(support.open(null, null));
+	}
+
+	@Test
+	public void testOpenWithMethodInvocationRetryCallbackShouldCallDoCloseMethod() {
+		final AtomicInteger callsOnDoOpenMethod = new AtomicInteger(0);
+		MethodInvocationRetryListenerSupport support = new MethodInvocationRetryListenerSupport() {
+			@Override
+			protected <T, E extends Throwable> boolean doOpen(RetryContext context,
+					MethodInvocationRetryCallback<T, E> callback) {
+				callsOnDoOpenMethod.incrementAndGet();
+				return true;
+			}
+		};
+		RetryContext context = mock(RetryContext.class);
+		MethodInvocationRetryCallback callback = mock(
+				MethodInvocationRetryCallback.class);
+		assertTrue(support.open(context, callback));
+
+		assertEquals(1, callsOnDoOpenMethod.get());
+	}
+
+}

--- a/src/test/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupportTests.java
+++ b/src/test/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupportTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -16,16 +16,16 @@
 
 package org.springframework.retry.listener;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.Test;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.interceptor.MethodInvocationRetryCallback;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
 
 public class MethodInvocationRetryListenerSupportTests {
 


### PR DESCRIPTION
Expose the MethodInvocation in the MethodInvocationRetryCallback in order to permit to concrete RetryListener implementations to inspect in detail the method called as well as its arguments. This information can be used in the retry listener for either detailed logging or monitoring for the proxied method invocations.

This pull-request has emerged based on the discussions held in #119 for the need of exposing detailed information about the AOP intercepted methods on which the spring-retry logic is being applied.