### PR TITLE
An idea for async retry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -320,8 +320,8 @@
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>

--- a/src/main/java/org/springframework/retry/backoff/BackoffPeriodSupplier.java
+++ b/src/main/java/org/springframework/retry/backoff/BackoffPeriodSupplier.java
@@ -2,5 +2,6 @@ package org.springframework.retry.backoff;
 
 import java.util.function.Supplier;
 
-public interface LastBackoffPeriodSupplier extends Supplier<Long> {
+public interface BackoffPeriodSupplier extends Supplier<Long> {
+
 }

--- a/src/main/java/org/springframework/retry/backoff/LastBackoffPeriodSupplier.java
+++ b/src/main/java/org/springframework/retry/backoff/LastBackoffPeriodSupplier.java
@@ -1,0 +1,6 @@
+package org.springframework.retry.backoff;
+
+import java.util.function.Supplier;
+
+public interface LastBackoffPeriodSupplier extends Supplier<Long> {
+}

--- a/src/main/java/org/springframework/retry/backoff/RememberPeriodSleeper.java
+++ b/src/main/java/org/springframework/retry/backoff/RememberPeriodSleeper.java
@@ -1,0 +1,22 @@
+package org.springframework.retry.backoff;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+
+public class RememberPeriodSleeper implements Sleeper, LastBackoffPeriodSupplier {
+
+    private static final Log logger = LogFactory.getLog(RememberPeriodSleeper.class);
+
+    private volatile Long lastBackoffPeriod;
+
+    @Override
+    public void sleep(long backOffPeriod) {
+        logger.debug("Remembering a sleeping period instead of sleeping: " + backOffPeriod);
+        lastBackoffPeriod = backOffPeriod;
+    }
+
+    @Override
+    public Long get() {
+        return lastBackoffPeriod;
+    }
+}

--- a/src/main/java/org/springframework/retry/backoff/RememberPeriodSleeper.java
+++ b/src/main/java/org/springframework/retry/backoff/RememberPeriodSleeper.java
@@ -3,20 +3,21 @@ package org.springframework.retry.backoff;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-public class RememberPeriodSleeper implements Sleeper, LastBackoffPeriodSupplier {
+public class RememberPeriodSleeper implements Sleeper, BackoffPeriodSupplier {
 
-    private static final Log logger = LogFactory.getLog(RememberPeriodSleeper.class);
+	private static final Log logger = LogFactory.getLog(RememberPeriodSleeper.class);
 
-    private volatile Long lastBackoffPeriod;
+	private volatile Long lastBackoffPeriod;
 
-    @Override
-    public void sleep(long backOffPeriod) {
-        logger.debug("Remembering a sleeping period instead of sleeping: " + backOffPeriod);
-        lastBackoffPeriod = backOffPeriod;
-    }
+	@Override
+	public void sleep(long backOffPeriod) {
+		logger.debug("Remembering a sleeping period instead of sleeping: " + backOffPeriod);
+		lastBackoffPeriod = backOffPeriod;
+	}
 
-    @Override
-    public Long get() {
-        return lastBackoffPeriod;
-    }
+	@Override
+	public Long get() {
+		return lastBackoffPeriod;
+	}
+
 }

--- a/src/main/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptor.java
@@ -25,7 +25,6 @@ import org.apache.commons.logging.LogFactory;
 
 import org.springframework.classify.Classifier;
 import org.springframework.retry.RecoveryCallback;
-import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryOperations;
 import org.springframework.retry.RetryState;

--- a/src/main/java/org/springframework/retry/support/AsyncRetryResultProcessor.java
+++ b/src/main/java/org/springframework/retry/support/AsyncRetryResultProcessor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryException;
+import org.springframework.retry.backoff.LastBackoffPeriodSupplier;
+
+/**
+ * @author Dave Syer
+ */
+public abstract class AsyncRetryResultProcessor<T> implements RetryResultProcessor<T> {
+    private static final Log logger = LogFactory.getLog(AsyncRetryResultProcessor.class);
+
+    protected T doNewAttempt(Supplier<Result<T>> supplier) throws Throwable {
+        logger.debug("Performing the next async callback invocation...");
+        return supplier.get().getOrThrow();
+    }
+
+    protected abstract T scheduleNewAttemptAfterDelay(
+            Supplier<Result<T>> supplier,
+            ScheduledExecutorService reschedulingExecutor,
+            long rescheduleAfterMillis,
+            RetryContext ctx
+    ) throws Throwable;
+
+    protected T handleException(Supplier<Result<T>> supplier,
+            Consumer<Throwable> handler,
+            Throwable throwable,
+            ScheduledExecutorService reschedulingExecutor,
+            LastBackoffPeriodSupplier lastBackoffPeriodSupplier,
+            RetryContext ctx) {
+        try {
+            handler.accept(unwrapIfNeed(throwable));
+
+            if (reschedulingExecutor == null || lastBackoffPeriodSupplier == null) {
+                return doNewAttempt(supplier);
+            } else {
+                long rescheduleAfterMillis = lastBackoffPeriodSupplier.get();
+                logger.debug("Scheduling a next retry with a delay = " + rescheduleAfterMillis + " millis...");
+                return scheduleNewAttemptAfterDelay(supplier, reschedulingExecutor, rescheduleAfterMillis, ctx);
+            }
+        }
+        catch (Throwable t) {
+            throw RetryTemplate.runtimeException(unwrapIfNeed(t));
+        }
+    }
+
+    static Throwable unwrapIfNeed(Throwable throwable) {
+        if (throwable instanceof ExecutionException
+                || throwable instanceof CompletionException
+                || throwable instanceof RetryException) {
+            return throwable.getCause();
+        } else {
+            return throwable;
+        }
+    }
+}

--- a/src/main/java/org/springframework/retry/support/CompletableFutureRetryResultProcessor.java
+++ b/src/main/java/org/springframework/retry/support/CompletableFutureRetryResultProcessor.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryException;
+
+/**
+ * A {@link RetryResultProcessor} for a {@link CompletableFuture}. If a
+ * {@link RetryCallback} returns a <code>CompletableFuture</code> this processor can be
+ * used internally by the {@link RetryTemplate} to wrap it and process the result.
+ *
+ * @author Dave Syer
+ */
+public class CompletableFutureRetryResultProcessor
+		implements RetryResultProcessor<CompletableFuture<?>> {
+
+	@Override
+	public Result<CompletableFuture<?>> process(CompletableFuture<?> completable,
+			Supplier<Result<CompletableFuture<?>>> supplier,
+			Consumer<Throwable> handler) {
+		@SuppressWarnings("unchecked")
+		CompletableFuture<Object> typed = (CompletableFuture<Object>) completable;
+		CompletableFuture<?> handle = typed
+				.thenApply(value -> CompletableFuture.completedFuture(value))
+				.exceptionally(throwable -> apply(supplier, handler, throwable))
+				.thenCompose(Function.identity());
+		return new Result<>(handle);
+	}
+
+	private CompletableFuture<Object> apply(
+			Supplier<Result<CompletableFuture<?>>> supplier, Consumer<Throwable> handler,
+			Throwable throwable) {
+		Throwable error = throwable;
+		try {
+			if (throwable instanceof ExecutionException
+					|| throwable instanceof CompletionException) {
+				error = throwable.getCause();
+			}
+			handler.accept(error);
+			Result<CompletableFuture<?>> result = supplier.get();
+			if (result.isComplete()) {
+				@SuppressWarnings("unchecked")
+				CompletableFuture<Object> output = (CompletableFuture<Object>) result
+						.getResult();
+				return output;
+			}
+			throw result.exception;
+		}
+		catch (InterruptedException e) {
+			Thread.currentThread().interrupt();
+			error = e;
+		}
+		catch (CompletionException e) {
+			error = e.getCause();
+		}
+		catch (ExecutionException e) {
+			error = e.getCause();
+		}
+		catch (RetryException e) {
+			error = e.getCause();
+		}
+		catch (Throwable e) {
+			error = e;
+		}
+		throw RetryTemplate.runtimeException(error);
+	}
+
+}

--- a/src/main/java/org/springframework/retry/support/FutureRetryResultProcessor.java
+++ b/src/main/java/org/springframework/retry/support/FutureRetryResultProcessor.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryException;
+
+/**
+ * A {@link RetryResultProcessor} for a plain {@link Future}. If a {@link RetryCallback}
+ * returns a <code>Future</code> this processor can be used internally by the
+ * {@link RetryTemplate} to wrap it and process the result.
+ *
+ * @author Dave Syer
+ */
+public class FutureRetryResultProcessor implements RetryResultProcessor<Future<?>> {
+
+	@Override
+	public Result<Future<?>> process(Future<?> future,
+			Supplier<Result<Future<?>>> supplier, Consumer<Throwable> handler) {
+		return new Result<Future<?>>(new FutureWrapper(future, supplier, handler));
+	}
+
+	private class FutureWrapper implements Future<Object> {
+
+		private Future<?> delegate;
+
+		private Supplier<Result<Future<?>>> supplier;
+
+		private Consumer<Throwable> handler;
+
+		FutureWrapper(Future<?> delegate, Supplier<Result<Future<?>>> supplier,
+				Consumer<Throwable> handler) {
+			this.delegate = delegate;
+			this.supplier = supplier;
+			this.handler = handler;
+		}
+
+		@Override
+		public boolean cancel(boolean mayInterruptIfRunning) {
+			return this.delegate.cancel(mayInterruptIfRunning);
+		}
+
+		@Override
+		public boolean isCancelled() {
+			return this.delegate.isCancelled();
+		}
+
+		@Override
+		public boolean isDone() {
+			return this.delegate.isDone();
+		}
+
+		@Override
+		public Object get() throws InterruptedException, ExecutionException {
+			try {
+				return this.delegate.get();
+			}
+			catch (ExecutionException e) {
+				return handle(e);
+			}
+		}
+
+		@Override
+		public Object get(long timeout, TimeUnit unit)
+				throws InterruptedException, ExecutionException, TimeoutException {
+			try {
+				return this.delegate.get(timeout, unit);
+			}
+			catch (ExecutionException e) {
+				return handle(e, timeout, unit);
+			}
+		}
+
+		private Object handle(ExecutionException throwable) {
+			return handle(throwable, -1, null);
+		}
+
+		private Object handle(ExecutionException throwable, long timeout, TimeUnit unit) {
+			Throwable error = throwable.getCause();
+			try {
+				this.handler.accept(error);
+				Result<Future<?>> result = this.supplier.get();
+				if (result.isComplete()) {
+					if (timeout < 0) {
+						return result.getResult().get();
+					}
+					else {
+						return result.getResult().get(timeout, unit);
+					}
+				}
+				throw result.exception;
+			}
+			catch (InterruptedException e) {
+				Thread.currentThread().interrupt();
+				error = e;
+			}
+			catch (CompletionException e) {
+				error = e.getCause();
+			}
+			catch (ExecutionException e) {
+				error = e.getCause();
+			}
+			catch (RetryException e) {
+				error = e.getCause();
+			}
+			catch (Throwable e) {
+				error = e;
+			}
+			throw RetryTemplate.runtimeException(error);
+		}
+
+	}
+
+}

--- a/src/main/java/org/springframework/retry/support/RetryResultProcessor.java
+++ b/src/main/java/org/springframework/retry/support/RetryResultProcessor.java
@@ -16,8 +16,12 @@
 
 package org.springframework.retry.support;
 
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
+
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.backoff.LastBackoffPeriodSupplier;
 
 /**
  * @author Dave Syer
@@ -25,7 +29,10 @@ import java.util.function.Supplier;
  */
 public interface RetryResultProcessor<T> {
 
-	Result<T> process(T input, Supplier<Result<T>> supplier, Consumer<Throwable> handler);
+	Result<T> process(T input, Supplier<Result<T>> supplier, Consumer<Throwable> handler,
+			ScheduledExecutorService reschedulingExecutor,
+			LastBackoffPeriodSupplier lastBackoffPeriodSupplier,
+			RetryContext ctx);
 
 	public static class Result<T> {
 
@@ -57,6 +64,12 @@ public interface RetryResultProcessor<T> {
 			return result;
 		}
 
+		public T getOrThrow() throws Throwable {
+			if (isComplete()) {
+				return result;
+			}
+			throw exception;
+		}
 	}
 
 }

--- a/src/main/java/org/springframework/retry/support/RetryResultProcessor.java
+++ b/src/main/java/org/springframework/retry/support/RetryResultProcessor.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+
+/**
+ * @author Dave Syer
+ * @param <T> the type of result from the retryable operation
+ */
+public interface RetryResultProcessor<T> {
+
+	Result<T> process(T input, Supplier<Result<T>> supplier, Consumer<Throwable> handler);
+
+	public static class Result<T> {
+
+		public Throwable exception;
+
+		private T result;
+
+		private boolean complete;
+
+		public Result(Throwable exception) {
+			this.exception = exception;
+			this.complete = false;
+		}
+
+		public Result(T result) {
+			this.result = result;
+			this.complete = true;
+		}
+
+		boolean isComplete() {
+			return this.complete;
+		}
+
+		public Throwable getException() {
+			return exception;
+		}
+
+		public T getResult() {
+			return result;
+		}
+
+	}
+
+}

--- a/src/main/java/org/springframework/retry/support/RetryResultProcessor.java
+++ b/src/main/java/org/springframework/retry/support/RetryResultProcessor.java
@@ -21,7 +21,7 @@ import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.springframework.retry.RetryContext;
-import org.springframework.retry.backoff.LastBackoffPeriodSupplier;
+import org.springframework.retry.backoff.BackoffPeriodSupplier;
 
 /**
  * @author Dave Syer
@@ -30,8 +30,7 @@ import org.springframework.retry.backoff.LastBackoffPeriodSupplier;
 public interface RetryResultProcessor<T> {
 
 	Result<T> process(T input, Supplier<Result<T>> supplier, Consumer<Throwable> handler,
-			ScheduledExecutorService reschedulingExecutor,
-			LastBackoffPeriodSupplier lastBackoffPeriodSupplier,
+			ScheduledExecutorService reschedulingExecutor, BackoffPeriodSupplier lastBackoffPeriodSupplier,
 			RetryContext ctx);
 
 	public static class Result<T> {
@@ -70,6 +69,7 @@ public interface RetryResultProcessor<T> {
 			}
 			throw exception;
 		}
+
 	}
 
 }

--- a/src/main/java/org/springframework/retry/support/RetryTemplate.java
+++ b/src/main/java/org/springframework/retry/support/RetryTemplate.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
+import org.springframework.classify.Classifier;
 import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.retry.RecoveryCallback;
 import org.springframework.retry.RetryCallback;
@@ -40,6 +41,7 @@ import org.springframework.retry.backoff.NoBackOffPolicy;
 import org.springframework.retry.policy.MapRetryContextCache;
 import org.springframework.retry.policy.RetryContextCache;
 import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetryResultProcessor.Result;
 
 /**
  * Template class that simplifies the execution of operations with retry semantics.
@@ -94,6 +96,8 @@ public class RetryTemplate implements RetryOperations {
 
 	private RetryContextCache retryContextCache = new MapRetryContextCache();
 
+	private Classifier<Object, RetryResultProcessor<?>> processors = null;
+
 	private boolean throwLastExceptionOnExhausted;
 
 	/**
@@ -130,6 +134,16 @@ public class RetryTemplate implements RetryOperations {
 	 */
 	public void setRetryContextCache(RetryContextCache retryContextCache) {
 		this.retryContextCache = retryContextCache;
+	}
+
+	/**
+	 * Public setter for the retry result processors (if any). Default null (same as
+	 * empty).
+	 * @param processors the processors to set
+	 */
+	public void setRetryResultProcessors(
+			Classifier<Object, RetryResultProcessor<?>> processors) {
+		this.processors = processors;
 	}
 
 	/**
@@ -286,74 +300,11 @@ public class RetryTemplate implements RetryOperations {
 				}
 			}
 
-			/*
-			 * We allow the whole loop to be skipped if the policy or context already
-			 * forbid the first try. This is used in the case of external retry to allow a
-			 * recovery in handleRetryExhausted without the callback processing (which
-			 * would throw an exception).
-			 */
-			while (canRetry(retryPolicy, context) && !context.isExhaustedOnly()) {
-
-				try {
-					if (this.logger.isDebugEnabled()) {
-						this.logger.debug("Retry: count=" + context.getRetryCount());
-					}
-					// Reset the last exception, so if we are successful
-					// the close interceptors will not think we failed...
-					lastException = null;
-					return retryCallback.doWithRetry(context);
-				}
-				catch (Throwable e) {
-
-					lastException = e;
-
-					try {
-						registerThrowable(retryPolicy, state, context, e);
-					}
-					catch (Exception ex) {
-						throw new TerminatedRetryException("Could not register throwable", ex);
-					}
-					finally {
-						doOnErrorInterceptors(retryCallback, context, e);
-					}
-
-					if (canRetry(retryPolicy, context) && !context.isExhaustedOnly()) {
-						try {
-							backOffPolicy.backOff(backOffContext);
-						}
-						catch (BackOffInterruptedException ex) {
-							lastException = e;
-							// back off was prevented by another thread - fail the retry
-							if (this.logger.isDebugEnabled()) {
-								this.logger.debug("Abort retry because interrupted: count=" + context.getRetryCount());
-							}
-							throw ex;
-						}
-					}
-
-					if (this.logger.isDebugEnabled()) {
-						this.logger.debug("Checking for rethrow: count=" + context.getRetryCount());
-					}
-
-					if (shouldRethrow(retryPolicy, context, state)) {
-						if (this.logger.isDebugEnabled()) {
-							this.logger.debug("Rethrow in retry for policy: count=" + context.getRetryCount());
-						}
-						throw RetryTemplate.<E>wrapIfNecessary(e);
-					}
-
-				}
-
-				/*
-				 * A stateful attempt that can retry may rethrow the exception before now,
-				 * but if we get this far in a stateful retry there's a reason for it,
-				 * like a circuit breaker or a rollback classifier.
-				 */
-				if (state != null && context.hasAttribute(GLOBAL_STATE)) {
-					break;
-				}
+			Result<T> result = loop(retryCallback, state, context, backOffContext);
+			if (result.isComplete()) {
+				return result.getResult();
 			}
-
+			lastException = result.exception;
 			if (state == null && this.logger.isDebugEnabled()) {
 				this.logger.debug("Retry failed last attempt: count=" + context.getRetryCount());
 			}
@@ -363,12 +314,129 @@ public class RetryTemplate implements RetryOperations {
 
 		}
 		catch (Throwable e) {
+			lastException = e;
 			throw RetryTemplate.<E>wrapIfNecessary(e);
 		}
 		finally {
 			close(retryPolicy, context, state, lastException == null || exhausted);
 			doCloseInterceptors(retryCallback, context, lastException);
 			RetrySynchronizationManager.clear();
+		}
+
+	}
+
+	private <T, E extends Throwable> Result<T> safeLoop(RetryCallback<T, E> retryCallback,
+			RetryState state, RetryContext context, BackOffContext backOffContext) {
+		try {
+			return loop(retryCallback, state, context, backOffContext);
+		}
+		catch (Throwable ex) {
+			throw runtimeException(ex);
+		}
+	}
+
+	private <T, E extends Throwable> Result<T> loop(RetryCallback<T, E> retryCallback,
+			RetryState state, RetryContext context, BackOffContext backOffContext)
+			throws E {
+
+		Throwable lastException = null;
+
+		/*
+		 * We allow the whole loop to be skipped if the policy or context already forbid
+		 * the first try. This is used in the case of external retry to allow a recovery
+		 * in handleRetryExhausted without the callback processing (which would throw an
+		 * exception).
+		 */
+		while (canRetry(this.retryPolicy, context) && !context.isExhaustedOnly()) {
+
+			try {
+
+				if (this.logger.isDebugEnabled()) {
+					this.logger.debug("Retry: count=" + context.getRetryCount());
+				}
+				T result = retryCallback.doWithRetry(context);
+				if (result != null && this.processors != null) {
+					@SuppressWarnings("unchecked")
+					RetryResultProcessor<T> processor = (RetryResultProcessor<T>) this.processors
+							.classify(result);
+					if (processor != null) {
+						return processor.process(result,
+								() -> safeLoop(retryCallback, state, context,
+										backOffContext),
+								error -> safeHandleLoopException(retryCallback, state,
+										context, backOffContext, error));
+					}
+				}
+				return new Result<>(result);
+
+			}
+			catch (Throwable e) {
+
+				lastException = e;
+				handleLoopException(retryCallback, state, context, backOffContext, e);
+
+			}
+			/*
+			 * A stateful attempt that can retry may rethrow the exception before now, but
+			 * if we get this far in a stateful retry there's a reason for it, like a
+			 * circuit breaker or a rollback classifier.
+			 */
+			if (state != null && context.hasAttribute(GLOBAL_STATE)) {
+				break;
+			}
+		}
+		return new Result<>(
+				lastException == null ? context.getLastThrowable() : lastException);
+	}
+
+	private <T, E extends Throwable> void safeHandleLoopException(
+			RetryCallback<T, E> retryCallback, RetryState state, RetryContext context,
+			BackOffContext backOffContext, Throwable e) {
+		try {
+			handleLoopException(retryCallback, state, context, backOffContext, e);
+		}
+		catch (Throwable ex) {
+			throw runtimeException(ex);
+		}
+	}
+
+	private <T, E extends Throwable> void handleLoopException(
+			RetryCallback<T, E> retryCallback, RetryState state, RetryContext context,
+			BackOffContext backOffContext, Throwable e) throws E {
+		try {
+			registerThrowable(this.retryPolicy, state, context, e);
+		}
+		catch (Exception ex) {
+			throw new TerminatedRetryException("Could not register throwable", ex);
+		}
+		finally {
+			doOnErrorInterceptors(retryCallback, context, e);
+		}
+
+		if (canRetry(this.retryPolicy, context) && !context.isExhaustedOnly()) {
+			try {
+				this.backOffPolicy.backOff(backOffContext);
+			}
+			catch (BackOffInterruptedException ex) {
+				// back off was prevented by another thread - fail the retry
+				if (this.logger.isDebugEnabled()) {
+					this.logger.debug("Abort retry because interrupted: count="
+							+ context.getRetryCount());
+				}
+				throw ex;
+			}
+		}
+
+		if (this.logger.isDebugEnabled()) {
+			this.logger.debug("Checking for rethrow: count=" + context.getRetryCount());
+		}
+
+		if (shouldRethrow(this.retryPolicy, context, state)) {
+			if (this.logger.isDebugEnabled()) {
+				this.logger.debug(
+						"Rethrow in retry for policy: count=" + context.getRetryCount());
+			}
+			throw RetryTemplate.<E>wrapIfNecessary(e);
 		}
 
 	}
@@ -583,6 +651,26 @@ public class RetryTemplate implements RetryOperations {
 		else if (throwable instanceof Exception) {
 			@SuppressWarnings("unchecked")
 			E rethrow = (E) throwable;
+			return rethrow;
+		}
+		else {
+			throw new RetryException("Exception in retry", throwable);
+		}
+	}
+
+	/**
+	 * Re-throws the original throwable if it is an RuntimeException, and wraps
+	 * non-exceptions into {@link RetryException}.
+	 * @param throwable the input errror
+	 * @return a RuntimeException if possible
+	 * @throws RetryException if the throwable is checked
+	 */
+	static RuntimeException runtimeException(Throwable throwable) throws RetryException {
+		if (throwable instanceof Error) {
+			throw (Error) throwable;
+		}
+		else if (throwable instanceof RuntimeException) {
+			RuntimeException rethrow = (RuntimeException) throwable;
 			return rethrow;
 		}
 		else {

--- a/src/main/java/org/springframework/retry/support/RetryTemplateBuilder.java
+++ b/src/main/java/org/springframework/retry/support/RetryTemplateBuilder.java
@@ -376,17 +376,17 @@ public class RetryTemplateBuilder {
 	}
 
 	/**
-	 * Enable async retry feature.
-	 * Due to no rescheduling executor is provided, a potential backoff will be performed
-	 * by Thread.sleep().
+	 * Enable async retry feature. Due to no rescheduling executor is provided, a
+	 * potential backoff will be performed by Thread.sleep().
+	 * @return A new RetryTemplateBuilder for an async retry
 	 */
 	public RetryTemplateBuilder asyncRetry() {
 		// todo: support interface classification (does not work yet)
 		this.processors.put(Future.class, new FutureRetryResultProcessor<>());
 		this.processors.put(FutureTask.class, new FutureRetryResultProcessor<>());
-		this.processors.put(CompletableFuture.class, new CompletableFutureRetryResultProcessor());
+		this.processors.put(CompletableFuture.class, new CompletableFutureRetryResultProcessor<Object>());
 
-		//todo
+		// todo
 		return this;
 	}
 
@@ -438,13 +438,10 @@ public class RetryTemplateBuilder {
 			retryTemplate.setReschedulingExecutor(executorService);
 
 			Assert.isTrue(backOffPolicy instanceof SleepingBackOffPolicy,
-					"Usage of a rescheduling executor makes sense "
-							+ "only with an instance of SleepingBackOffPolicy"
-			);
+					"Usage of a rescheduling executor makes sense " + "only with an instance of SleepingBackOffPolicy");
 		}
 
-		SubclassClassifier<Object, RetryResultProcessor<?>> classifier =
-				new SubclassClassifier<>(processors, null);
+		SubclassClassifier<Object, RetryResultProcessor<?>> classifier = new SubclassClassifier<>(processors, null);
 		retryTemplate.setRetryResultProcessors(classifier);
 
 		return retryTemplate;

--- a/src/test/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupportTests.java
+++ b/src/test/java/org/springframework/retry/listener/MethodInvocationRetryListenerSupportTests.java
@@ -51,7 +51,7 @@ public class MethodInvocationRetryListenerSupportTests {
 			}
 		};
 		RetryContext context = mock(RetryContext.class);
-		MethodInvocationRetryCallback callback = mock(MethodInvocationRetryCallback.class);
+		MethodInvocationRetryCallback<?, ?> callback = mock(MethodInvocationRetryCallback.class);
 		support.close(context, callback, null);
 
 		assertEquals(1, callsOnDoCloseMethod.get());
@@ -68,7 +68,7 @@ public class MethodInvocationRetryListenerSupportTests {
 			}
 		};
 		RetryContext context = mock(RetryContext.class);
-		RetryCallback callback = mock(RetryCallback.class);
+		RetryCallback<?, ?> callback = mock(RetryCallback.class);
 		support.close(context, callback, null);
 
 		assertEquals(0, callsOnDoCloseMethod.get());
@@ -96,7 +96,7 @@ public class MethodInvocationRetryListenerSupportTests {
 			}
 		};
 		RetryContext context = mock(RetryContext.class);
-		MethodInvocationRetryCallback callback = mock(MethodInvocationRetryCallback.class);
+		MethodInvocationRetryCallback<?, ?> callback = mock(MethodInvocationRetryCallback.class);
 		support.onError(context, callback, null);
 
 		assertEquals(1, callsOnDoOnErrorMethod.get());
@@ -120,7 +120,7 @@ public class MethodInvocationRetryListenerSupportTests {
 			}
 		};
 		RetryContext context = mock(RetryContext.class);
-		MethodInvocationRetryCallback callback = mock(MethodInvocationRetryCallback.class);
+		MethodInvocationRetryCallback<?, ?> callback = mock(MethodInvocationRetryCallback.class);
 		assertTrue(support.open(context, callback));
 
 		assertEquals(1, callsOnDoOpenMethod.get());

--- a/src/test/java/org/springframework/retry/support/AbstractAsyncRetryTest.java
+++ b/src/test/java/org/springframework/retry/support/AbstractAsyncRetryTest.java
@@ -1,0 +1,227 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.function.Supplier;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.backoff.BackOffContext;
+import org.springframework.retry.backoff.BackOffInterruptedException;
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.retry.backoff.RememberPeriodSleeper;
+import org.springframework.retry.backoff.Sleeper;
+
+import static org.junit.Assert.assertTrue;
+import static org.springframework.retry.util.test.TestUtils.getPropertyValue;
+
+/**
+ * @author Dave Syer
+ */
+public class AbstractAsyncRetryTest {
+	
+	/* ---------------- Async callbacks implementations for different types -------------- */
+
+	static class CompletableFutureRetryCallback
+			extends AbstractRetryCallback<CompletableFuture<Object>> {
+
+		@Override
+		public CompletableFuture<Object> schedule(Supplier<Object> callback, ExecutorService workerExecutor) {
+			return CompletableFuture.supplyAsync(callback, workerExecutor);
+		}
+
+		@Override
+		Object awaitItself(CompletableFuture<Object> asyncType) {
+			return asyncType.join();
+		}
+	}
+
+	static class FutureRetryCallback
+			extends AbstractRetryCallback<Future<Object>> {
+		
+		@Override
+		public Future<Object> schedule(Supplier<Object> callback, ExecutorService executor) {
+			return executor.submit(callback::get);
+		}
+
+		@Override
+		Object awaitItself(Future<Object> asyncType) throws Throwable {
+			return asyncType.get();
+		}
+	}
+
+	static abstract class AbstractRetryCallback<A>
+			implements RetryCallback<A, Exception> {
+
+		final Object defaultResult = new Object();
+		final Log logger = LogFactory.getLog(getClass());
+
+		final AtomicInteger jobAttempts = new AtomicInteger();
+		final AtomicInteger schedulingAttempts = new AtomicInteger();
+
+		volatile int attemptsBeforeSchedulingSuccess;
+		volatile int attemptsBeforeJobSuccess;
+
+		volatile RuntimeException exceptionToThrow = new RuntimeException();
+
+		volatile Function<RetryContext, Object> resultSupplier = ctx -> defaultResult;
+		volatile Consumer<RetryContext> customCodeBeforeScheduling = ctx -> {};
+
+		final List<String> schedulerThreadNames = new CopyOnWriteArrayList<>();
+		final List<Long> invocationMoments = new CopyOnWriteArrayList<>();
+
+		final ExecutorService workerExecutor = Executors.newSingleThreadExecutor(
+				getNamedThreadFactory(WORKER_THREAD_NAME)
+		);
+
+		public abstract A schedule(Supplier<Object> callback, ExecutorService executor);
+
+		abstract Object awaitItself(A asyncType) throws Throwable;
+
+		@Override
+		public A doWithRetry(RetryContext ctx)
+				throws Exception {
+			rememberThreadName();
+			rememberInvocationMoment();
+
+			throwIfSchedulingTooEarly();
+
+			customCodeBeforeScheduling.accept(ctx);
+
+			return schedule(() -> {
+				try {
+					// a hack to avoid running CompletableFuture#thenApplyAsync in the caller thread
+					Thread.sleep(100L);
+				} catch (InterruptedException e) {
+					e.printStackTrace();
+				}
+				throwIfJobTooEarly();
+				logger.debug("Succeeding the callback...");
+				return resultSupplier.apply(ctx);
+			}, workerExecutor);
+		}
+		
+		void rememberInvocationMoment() {
+			invocationMoments.add(System.currentTimeMillis());
+		}
+
+		void rememberThreadName() {
+			schedulerThreadNames.add(Thread.currentThread().getName());
+		}
+
+		void throwIfJobTooEarly() {
+			if (this.jobAttempts.incrementAndGet() < this.attemptsBeforeJobSuccess) {
+				logger.debug("Failing job...");
+				throw this.exceptionToThrow;
+			}
+		}
+
+		void throwIfSchedulingTooEarly() {
+			if (this.schedulingAttempts.incrementAndGet() < this.attemptsBeforeSchedulingSuccess) {
+				logger.debug("Failing scheduling...");
+				throw this.exceptionToThrow;
+			}
+		}
+
+		void setAttemptsBeforeJobSuccess(int attemptsBeforeJobSuccess) {
+			this.attemptsBeforeJobSuccess = attemptsBeforeJobSuccess;
+		}
+
+		void setAttemptsBeforeSchedulingSuccess(int attemptsBeforeSchedulingSuccess) {
+			this.attemptsBeforeSchedulingSuccess = attemptsBeforeSchedulingSuccess;
+		}
+
+		void setExceptionToThrow(RuntimeException exceptionToThrow) {
+			this.exceptionToThrow = exceptionToThrow;
+		}
+
+		void setResultSupplier(Function<RetryContext, Object> resultSupplier) {
+			this.resultSupplier = resultSupplier;
+		}
+
+		void setCustomCodeBeforeScheduling(Consumer<RetryContext> customCodeBeforeScheduling) {
+			this.customCodeBeforeScheduling = customCodeBeforeScheduling;
+		}
+	}
+
+
+	static class MockBackOffStrategy implements BackOffPolicy {
+
+		public int backOffCalls;
+
+		public int startCalls;
+
+		@Override
+		public BackOffContext start(RetryContext status) {
+			if (!status.hasAttribute(MockBackOffStrategy.class.getName())) {
+				this.startCalls++;
+				status.setAttribute(MockBackOffStrategy.class.getName(), true);
+			}
+			return null;
+		}
+
+		@Override
+		public void backOff(BackOffContext backOffContext)
+				throws BackOffInterruptedException {
+			this.backOffCalls++;
+		}
+
+	}
+
+	/* ---------------- Utilities -------------- */
+
+	static final String SCHEDULER_THREAD_NAME = "scheduler";
+    static final String WORKER_THREAD_NAME = "worker";
+
+	static ScheduledExecutorService getNamedScheduledExecutor() {
+		return Executors.newScheduledThreadPool(
+				1,
+                getNamedThreadFactory(AbstractAsyncRetryTest.SCHEDULER_THREAD_NAME)
+		);
+	}
+
+    static ThreadFactory getNamedThreadFactory(String threadName) {
+        return new ThreadFactory() {
+            @Override
+            public Thread newThread(Runnable r) {
+                Thread thread = new Thread(r);
+                thread.setName(threadName);
+                return thread;
+            }
+        };
+    }
+
+    void assertRememberingSleeper(RetryTemplate template) {
+        // The sleeper of the backoff policy should be an instance of RememberPeriodSleeper, means not Thread.sleep()
+        BackOffPolicy backOffPolicy = getPropertyValue(template, "backOffPolicy", BackOffPolicy.class);
+        Sleeper sleeper = getPropertyValue(backOffPolicy, "sleeper", Sleeper.class);
+        assertTrue(sleeper instanceof RememberPeriodSleeper);
+    }
+}

--- a/src/test/java/org/springframework/retry/support/AsyncReschedulingTests.java
+++ b/src/test/java/org/springframework/retry/support/AsyncReschedulingTests.java
@@ -1,0 +1,435 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.function.Supplier;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyZeroInteractions;
+
+public class AsyncReschedulingTests extends AbstractAsyncRetryTest {
+
+	/**
+	 * Scheduling retry + job immediate success.
+	 *
+	 * - async callback succeeds at 3rd attempt
+	 * - actual job succeeds on 1st attempt
+	 * - no backoff
+	 */
+
+	@Test
+	public void testInitialSchedulingEventualSuccessCF() throws Throwable {
+		doTestInitialSchedulingEventualSuccess(new CompletableFutureRetryCallback());
+	}
+
+	@Test
+	public void testInitialSchedulingEventualSuccessF() throws Throwable {
+		doTestInitialSchedulingEventualSuccess(new FutureRetryCallback());
+	}
+
+	private <A> void doTestInitialSchedulingEventualSuccess(AbstractRetryCallback<A> callback) throws Throwable {
+		RetryTemplate template = RetryTemplate.builder()
+				.maxAttempts(5)
+				.noBackoff()
+				.asyncRetry()
+				.build();
+
+		callback.setAttemptsBeforeSchedulingSuccess(3);
+		callback.setAttemptsBeforeJobSuccess(1);
+		assertEquals(callback.defaultResult, callback.awaitItself(template.execute(callback)));
+
+		// All invocations before first successful scheduling should be performed by the caller thread
+		assertEquals(Collections.nCopies(3, Thread.currentThread().getName()), callback.schedulerThreadNames);
+
+		assertEquals(1, callback.jobAttempts.get());
+	}
+
+    /**
+	 * Immediate success of both scheduling and job.
+	 *
+     * - async callback, that does not fail itself
+     * - actual job succeeds on 1st attempt
+     * - backoff is not necessary
+     */
+    
+	@Test
+	public void testImmediateSuccessCF() throws Throwable {
+		doTestImmediateSuccess(new CompletableFutureRetryCallback());
+	}
+
+	@Test
+	public void testImmediateSuccessF() throws Throwable {
+		doTestImmediateSuccess(new FutureRetryCallback());
+	}
+
+	private <A> void doTestImmediateSuccess(AbstractRetryCallback<A> callback) throws Throwable {
+		ScheduledExecutorService executor = mock(ScheduledExecutorService.class);
+
+		RetryTemplate template = RetryTemplate.builder()
+				.fixedBackoff(10000)
+				.asyncRetry(executor)
+				.build();
+
+		callback.setAttemptsBeforeSchedulingSuccess(1);
+		callback.setAttemptsBeforeJobSuccess(1);
+		assertEquals(callback.defaultResult, callback.awaitItself(template.execute(callback)));
+
+		// Single invocation should be performed by the caller thread
+		assertEquals(Collections.singletonList(Thread.currentThread().getName()), callback.schedulerThreadNames);
+
+		assertEquals(1, callback.jobAttempts.get());
+
+		// No interaction with the rescheduling executor should be performed if the first execution of the job succeeds.
+		verifyZeroInteractions(executor);
+	}
+
+    /**
+	 * Async retry with rescheduler.
+	 * 
+     * - async callback, that does not fail itself
+     * - actual job succeeds on 3rd attempt
+     * - backoff is performed using executor, without Thread.sleep()
+     */
+
+	@Test
+	public void testAsyncRetryWithReschedulerCF() throws Throwable {
+		doTestAsyncRetryWithRescheduler(new CompletableFutureRetryCallback());
+	}
+
+	@Test
+	public void testAsyncRetryWithReschedulerF() throws Throwable {
+		doTestAsyncRetryWithRescheduler(new FutureRetryCallback());
+	}
+	
+	private <A> void doTestAsyncRetryWithRescheduler(AbstractRetryCallback<A> callback) throws Throwable {
+
+        int targetFixedBackoff = 150;
+
+		ScheduledExecutorService executor = getNamedScheduledExecutor();
+
+        RetryTemplate template = RetryTemplate.builder()
+				.maxAttempts(4)
+				.fixedBackoff(targetFixedBackoff)
+				.asyncRetry(executor)
+				.build();
+        
+        callback.setAttemptsBeforeSchedulingSuccess(1);
+		callback.setAttemptsBeforeJobSuccess(3);
+		assertEquals(callback.defaultResult, callback.awaitItself(template.execute(callback)));
+		assertEquals(3, callback.jobAttempts.get());
+
+		// All invocations after the first successful scheduling should be performed by the the rescheduler thread
+		assertEquals(Arrays.asList(
+				Thread.currentThread().getName(),
+				SCHEDULER_THREAD_NAME,
+				SCHEDULER_THREAD_NAME
+		), callback.schedulerThreadNames);
+
+		assertRememberingSleeper(template);
+
+        // Expected backoff should be performed
+        List<Long> moments = callback.invocationMoments;
+        for (int i = 0; i < moments.size() - 1; i++) {
+            long approxBackoff = moments.get(i + 1) - moments.get(i);
+            assertTrue(approxBackoff > targetFixedBackoff);
+        }
+    }
+
+    /**
+	 * Async retry without backoff
+	 * 
+     * - async callback succeeds on 2nd attempt
+     * - actual job succeeds on 3nd attempt
+     * - default zero backoff is used (which has no sleeper at all),
+     *   and therefore rescheduler executor is not used at all
+     */
+
+	@Test
+	public void testAsyncRetryWithoutBackoffCF() throws Throwable {
+		doTestAsyncRetryWithoutBackoff(new CompletableFutureRetryCallback());
+	}
+
+	// todo: problem: a Future can start retrying only when user calls get(). Consider to not support Future at all.
+	/*@Test
+	public void testAsyncRetryWithoutBackoffF() throws Throwable {
+		doTestAsyncRetryWithoutBackoff(new FutureRetryCallback());
+	}*/
+	
+    private <A> void doTestAsyncRetryWithoutBackoff(AbstractRetryCallback<A> callback) throws Throwable {
+        RetryTemplate template = RetryTemplate.builder()
+                .maxAttempts(4)
+				.asyncRetry()
+                .build();
+
+        callback.setAttemptsBeforeSchedulingSuccess(2);
+        callback.setAttemptsBeforeJobSuccess(3);
+        assertEquals(callback.defaultResult, callback.awaitItself(template.execute(callback)));
+        assertEquals(4, callback.schedulingAttempts.get());
+        assertEquals(3, callback.jobAttempts.get());
+
+        // All invocations after the first successful scheduling should be performed by the
+		// the worker thread (because not backoff and no rescheduler thread)
+        assertEquals(Arrays.asList(
+                Thread.currentThread().getName(),
+                Thread.currentThread().getName(),
+				WORKER_THREAD_NAME,
+				WORKER_THREAD_NAME
+        ), callback.schedulerThreadNames);
+    }
+
+	/**
+	 * Exhausted on scheduling retries
+	 */
+
+	@Test
+	public void testExhaustOnSchedulingCF() throws Throwable {
+		doTestExhaustOnScheduling(new CompletableFutureRetryCallback());
+	}
+
+	@Test
+	public void testExhaustOnSchedulingF() throws Throwable {
+		doTestExhaustOnScheduling(new FutureRetryCallback());
+	}
+	
+	private <A> void doTestExhaustOnScheduling(AbstractRetryCallback<A> callback) throws Throwable {
+		RetryTemplate template = RetryTemplate.builder()
+				.maxAttempts(2)
+				.asyncRetry()
+				.fixedBackoff(100)
+				.build();
+
+		callback.setAttemptsBeforeSchedulingSuccess(5);
+		callback.setAttemptsBeforeJobSuccess(5);
+
+		try {
+			callback.awaitItself(template.execute(callback));
+			fail("An exception should be thrown above");
+		} catch (Exception e) {
+			assertSame(e, callback.exceptionToThrow);
+		}
+
+		assertEquals(Arrays.asList(
+				Thread.currentThread().getName(),
+				Thread.currentThread().getName()
+		), callback.schedulerThreadNames);
+	}
+
+	/**
+	 * Exhausted on job retries
+	 */
+	
+	@Test
+	public void testExhaustOnJobWithReschedulerCF() throws Throwable {
+		doTestExhaustOnJobWithRescheduler(new CompletableFutureRetryCallback());
+	}
+
+	@Test
+	public void testExhaustOnJobWithReschedulerF() throws Throwable {
+		doTestExhaustOnJobWithRescheduler(new FutureRetryCallback());
+	}
+
+	private <A> void doTestExhaustOnJobWithRescheduler(AbstractRetryCallback<A> callback) throws Throwable {
+		RetryTemplate template = RetryTemplate.builder()
+				.maxAttempts(5)
+				.asyncRetry(getNamedScheduledExecutor())
+				.exponentialBackoff(10, 2, 100)
+				.build();
+
+		callback.setAttemptsBeforeSchedulingSuccess(1);
+		callback.setAttemptsBeforeJobSuccess(6);
+
+		try {
+			Object v = callback.awaitItself(template.execute(callback));
+			fail("An exception should be thrown above");
+			// Single wrapping by CompletionException is expected by CompletableFuture contract
+		} catch (Exception ce) {
+			assertSame(ce.getCause(), callback.exceptionToThrow);
+		}
+
+		assertEquals(Arrays.asList(
+				Thread.currentThread().getName(),
+				SCHEDULER_THREAD_NAME,
+				SCHEDULER_THREAD_NAME,
+				SCHEDULER_THREAD_NAME,
+				SCHEDULER_THREAD_NAME
+		), callback.schedulerThreadNames);
+	}
+
+	// todo: rejected execution
+	// todo: interrupt executor
+	// rethrow not too late
+
+
+	/*
+	 * Nested rescheduling
+	 */
+
+	@Test
+	public void testNested() throws Throwable {
+		ScheduledExecutorService executor = getNamedScheduledExecutor();
+
+		RetryTemplate outerTemplate = RetryTemplate.builder()
+				.infiniteRetry()
+				.asyncRetry(executor)
+				.fixedBackoff(10)
+				.build();
+
+		RetryTemplate innerTemplate = RetryTemplate.builder()
+				.infiniteRetry()
+				.asyncRetry(executor)
+				.fixedBackoff(10)
+				.build();
+
+		CompletableFutureRetryCallback innerCallback = new CompletableFutureRetryCallback();
+		innerCallback.setAttemptsBeforeSchedulingSuccess(3);
+		innerCallback.setAttemptsBeforeJobSuccess(3);
+		innerCallback.setCustomCodeBeforeScheduling(ctx -> {
+			// The current context should be available via RetrySynchronizationManager while scheduling
+			// (withing user's async callback itself)
+			assertEquals(ctx, RetrySynchronizationManager.getContext());
+
+			// We have no control over user's worker thread, so we can not implicitly set/get the parent
+			// context via RetrySynchronizationManager.
+			assertNull(ctx.getParent());
+		});
+		innerCallback.setResultSupplier(ctx -> {
+			// There is no way to implicitly pass the context into the worker thread, because the worker executor,
+			// thread and callback are fully controlled by the user. The retry engine deals with only
+			// scheduling/rescheduling and their result (e.g. CompletableFuture)
+			assertNull(RetrySynchronizationManager.getContext());
+
+			return innerCallback.defaultResult;
+		});
+
+		CompletableFutureRetryCallback outerCallback = new CompletableFutureRetryCallback();
+		outerCallback.setAttemptsBeforeSchedulingSuccess(3);
+		outerCallback.setAttemptsBeforeJobSuccess(3);
+		outerCallback.setCustomCodeBeforeScheduling(ctx -> {
+			// The current context should be available via RetrySynchronizationManager while scheduling
+			// (withing user's async callback itself)
+			assertEquals(ctx, RetrySynchronizationManager.getContext());
+		});
+		outerCallback.setResultSupplier(ctx -> {
+			try {
+				assertNull(RetrySynchronizationManager.getContext());
+				CompletableFuture<Object> innerResultFuture = innerTemplate.execute(innerCallback);
+				assertNull(RetrySynchronizationManager.getContext());
+
+				Object innerResult = innerCallback.awaitItself(innerResultFuture);
+				assertNull(RetrySynchronizationManager.getContext());
+
+				// Return inner result as outer result
+				return innerResult;
+			} catch (Exception e) {
+				throw new RuntimeException(e);
+			}
+		});
+
+
+		Object outerResult = outerCallback.awaitItself(outerTemplate.execute(outerCallback));
+		assertEquals(innerCallback.defaultResult, outerResult);
+
+		assertEquals(Arrays.asList(
+				// initial scheduling of the outer callback
+				Thread.currentThread().getName(),
+				Thread.currentThread().getName(),
+				Thread.currentThread().getName(),
+				// rescheduling of the outer callback
+				SCHEDULER_THREAD_NAME,
+				SCHEDULER_THREAD_NAME
+		), outerCallback.schedulerThreadNames);
+
+		assertEquals(Arrays.asList(
+				// initial scheduling of the inner callback
+				WORKER_THREAD_NAME,
+				WORKER_THREAD_NAME,
+				WORKER_THREAD_NAME,
+				// rescheduling of the inner callback
+				SCHEDULER_THREAD_NAME,
+				SCHEDULER_THREAD_NAME
+		), innerCallback.schedulerThreadNames);
+	}
+
+
+	/**
+	 * Test with additional chained completable futures.
+	 */
+	
+	@Test
+	public void testAdditionalChainedCF() throws Throwable {
+
+		Object additionalInnerResult = new Object();
+		CompletableFutureRetryCallback callback = new CompletableFutureRetryCallback() {
+			@Override
+			public CompletableFuture<Object> schedule(Supplier<Object> callback, ExecutorService workerExecutor) {
+				return super.schedule(callback, workerExecutor)
+						// Additional inner cf
+						.thenApply(r -> {
+							assertEquals(this.defaultResult, r);
+							return additionalInnerResult;
+						});
+			}
+		};
+		RetryTemplate template = RetryTemplate.builder()
+				.maxAttempts(4)
+				.asyncRetry()
+				.build();
+
+		callback.setAttemptsBeforeSchedulingSuccess(2);
+		callback.setAttemptsBeforeJobSuccess(3);
+
+		Object additionalOuterResult = new Object();
+		CompletableFuture<Object> cf = template.execute(callback)
+				// Additional step
+				.thenApply(r -> {
+					assertEquals(additionalInnerResult, r);
+					return additionalOuterResult;
+				});
+
+		assertEquals(additionalOuterResult, callback.awaitItself(cf));
+		assertEquals(4, callback.schedulingAttempts.get());
+		assertEquals(3, callback.jobAttempts.get());
+
+		// All invocations after the first successful scheduling should be performed by the
+		// the worker thread (because not backoff and no rescheduler thread)
+		assertEquals(Arrays.asList(
+				Thread.currentThread().getName(),
+				Thread.currentThread().getName(),
+				WORKER_THREAD_NAME,
+				WORKER_THREAD_NAME
+		), callback.schedulerThreadNames);
+	}
+
+
+	// todo: test stateful rescheduling
+	// todo: test RejectedExecutionException on rescheduler
+	// todo: test InterruptedException
+	// todo: support declarative async
+}

--- a/src/test/java/org/springframework/retry/support/AsyncRetryTemplateTests.java
+++ b/src/test/java/org/springframework/retry/support/AsyncRetryTemplateTests.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ForkJoinTask;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import org.springframework.classify.SubclassClassifier;
+import org.springframework.retry.RetryCallback;
+import org.springframework.retry.RetryContext;
+import org.springframework.retry.backoff.BackOffContext;
+import org.springframework.retry.backoff.BackOffInterruptedException;
+import org.springframework.retry.backoff.BackOffPolicy;
+import org.springframework.retry.policy.SimpleRetryPolicy;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+/**
+ * @author Dave Syer
+ */
+public class AsyncRetryTemplateTests {
+
+	private RetryTemplate retryTemplate;
+
+	@Before
+	@SuppressWarnings({ "unchecked", "rawtypes" })
+	public void init() {
+		this.retryTemplate = new RetryTemplate();
+		Map<Class<?>, RetryResultProcessor<?>> map = new HashMap<>();
+		map.put(Future.class, new FutureRetryResultProcessor());
+		map.put(CompletableFuture.class, new CompletableFutureRetryResultProcessor());
+		SubclassClassifier processors = new SubclassClassifier(map,
+				(RetryResultProcessor<?>) null);
+		this.retryTemplate.setRetryResultProcessors(processors);
+	}
+
+	@Test
+	public void testSuccessfulRetryCompletable() throws Throwable {
+		for (int x = 1; x <= 10; x++) {
+			CompletableFutureRetryCallback callback = new CompletableFutureRetryCallback();
+			callback.setAttemptsBeforeSuccess(x);
+			SimpleRetryPolicy policy = new SimpleRetryPolicy(x);
+			this.retryTemplate.setRetryPolicy(policy);
+			CompletableFuture<Object> result = this.retryTemplate.execute(callback);
+			assertEquals(CompletableFutureRetryCallback.RESULT,
+					result.get(1000L, TimeUnit.MILLISECONDS));
+			assertEquals(x, callback.attempts);
+		}
+	}
+
+	@Test
+	public void testSuccessfulRetryFuture() throws Throwable {
+		for (int x = 1; x <= 10; x++) {
+			FutureRetryCallback callback = new FutureRetryCallback();
+			callback.setAttemptsBeforeSuccess(x);
+			SimpleRetryPolicy policy = new SimpleRetryPolicy(x);
+			this.retryTemplate.setRetryPolicy(policy);
+			Future<Object> result = this.retryTemplate.execute(callback);
+			assertEquals(FutureRetryCallback.RESULT,
+					result.get(1000L, TimeUnit.MILLISECONDS));
+			assertEquals(x, callback.attempts);
+		}
+	}
+
+	@Test
+	public void testBackOffInvoked() throws Throwable {
+		for (int x = 1; x <= 10; x++) {
+			CompletableFutureRetryCallback callback = new CompletableFutureRetryCallback();
+			MockBackOffStrategy backOff = new MockBackOffStrategy();
+			callback.setAttemptsBeforeSuccess(x);
+			SimpleRetryPolicy policy = new SimpleRetryPolicy(10);
+			this.retryTemplate.setRetryPolicy(policy);
+			this.retryTemplate.setBackOffPolicy(backOff);
+			CompletableFuture<Object> result = this.retryTemplate.execute(callback);
+			assertEquals(CompletableFutureRetryCallback.RESULT,
+					result.get(1000L, TimeUnit.MILLISECONDS));
+			assertEquals(x, callback.attempts);
+			assertEquals(1, backOff.startCalls);
+			assertEquals(x - 1, backOff.backOffCalls);
+		}
+	}
+
+	@Test
+	public void testNoSuccessRetry() throws Throwable {
+		CompletableFutureRetryCallback callback = new CompletableFutureRetryCallback();
+		// Something that won't be thrown by JUnit...
+		callback.setExceptionToThrow(new IllegalArgumentException());
+		callback.setAttemptsBeforeSuccess(Integer.MAX_VALUE);
+		int retryAttempts = 2;
+		this.retryTemplate.setRetryPolicy(new SimpleRetryPolicy(retryAttempts));
+		try {
+			CompletableFuture<Object> result = this.retryTemplate.execute(callback);
+			result.get(1000L, TimeUnit.MILLISECONDS);
+			fail("Expected IllegalArgumentException");
+		}
+		catch (ExecutionException e) {
+			assertTrue("Expected IllegalArgumentException",
+					e.getCause() instanceof IllegalArgumentException);
+			assertEquals(retryAttempts, callback.attempts);
+			return;
+		}
+		fail("Expected IllegalArgumentException");
+	}
+
+	private static class CompletableFutureRetryCallback
+			implements RetryCallback<CompletableFuture<Object>, Exception> {
+
+		public static Object RESULT = new Object();
+
+		private int attempts;
+
+		private int attemptsBeforeSuccess;
+
+		private RuntimeException exceptionToThrow = new RuntimeException();
+
+		@Override
+		public CompletableFuture<Object> doWithRetry(RetryContext status)
+				throws Exception {
+			// !!!! Don't do this in real life - use a thread pool
+			return CompletableFuture.supplyAsync(() -> {
+				this.attempts++;
+				if (this.attempts < this.attemptsBeforeSuccess) {
+					throw this.exceptionToThrow;
+				}
+				return RESULT;
+			});
+		}
+
+		public void setAttemptsBeforeSuccess(int attemptsBeforeSuccess) {
+			this.attemptsBeforeSuccess = attemptsBeforeSuccess;
+		}
+
+		public void setExceptionToThrow(RuntimeException exceptionToThrow) {
+			this.exceptionToThrow = exceptionToThrow;
+		}
+
+	}
+
+	private static class FutureRetryCallback
+			implements RetryCallback<Future<Object>, Exception> {
+
+		public static Object RESULT = new Object();
+
+		private int attempts;
+
+		private int attemptsBeforeSuccess;
+
+		private RuntimeException exceptionToThrow = new RuntimeException();
+
+		@Override
+		public Future<Object> doWithRetry(RetryContext status) throws Exception {
+			// !!!! Don't do this in real life - use a thread pool
+			return ForkJoinTask.adapt(() -> {
+				this.attempts++;
+				if (this.attempts < this.attemptsBeforeSuccess) {
+					throw this.exceptionToThrow;
+				}
+				return RESULT;
+			}).fork();
+		}
+
+		public void setAttemptsBeforeSuccess(int attemptsBeforeSuccess) {
+			this.attemptsBeforeSuccess = attemptsBeforeSuccess;
+		}
+
+	}
+
+	private static class MockBackOffStrategy implements BackOffPolicy {
+
+		public int backOffCalls;
+
+		public int startCalls;
+
+		@Override
+		public BackOffContext start(RetryContext status) {
+			if (!status.hasAttribute(MockBackOffStrategy.class.getName())) {
+				this.startCalls++;
+				status.setAttribute(MockBackOffStrategy.class.getName(), true);
+			}
+			return null;
+		}
+
+		@Override
+		public void backOff(BackOffContext backOffContext)
+				throws BackOffInterruptedException {
+			this.backOffCalls++;
+		}
+
+	}
+
+}

--- a/src/test/java/org/springframework/retry/support/AsyncRetryTemplateTests.java
+++ b/src/test/java/org/springframework/retry/support/AsyncRetryTemplateTests.java
@@ -23,8 +23,6 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.logging.Log;
-import org.apache.commons.logging.LogFactory;
 import org.apache.log4j.ConsoleAppender;
 import org.apache.log4j.Level;
 import org.apache.log4j.Logger;
@@ -36,12 +34,8 @@ import org.springframework.classify.SubclassClassifier;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.verify;
-import static org.springframework.retry.util.test.TestUtils.getPropertyValue;
 
 /**
  * @author Dave Syer
@@ -49,23 +43,22 @@ import static org.springframework.retry.util.test.TestUtils.getPropertyValue;
 public class AsyncRetryTemplateTests extends AbstractAsyncRetryTest {
 
 	private RetryTemplate retryTemplate;
-	
+
 	@Before
 	@SuppressWarnings({ "unchecked", "rawtypes" })
 	public void init() {
-//		org.apache.log4j.BasicConfigurator.configure();
-		
+		// org.apache.log4j.BasicConfigurator.configure();
+
 		Logger root = Logger.getRootLogger();
 		root.removeAllAppenders();
 		root.addAppender(new ConsoleAppender(new PatternLayout("%r [%t] %p %c{1} %x - %m%n")));
 		Logger.getRootLogger().setLevel(Level.TRACE);
-		
+
 		this.retryTemplate = new RetryTemplate();
 		Map<Class<?>, RetryResultProcessor<?>> map = new HashMap<>();
 		map.put(Future.class, new FutureRetryResultProcessor());
 		map.put(CompletableFuture.class, new CompletableFutureRetryResultProcessor());
-		SubclassClassifier processors = new SubclassClassifier(map,
-				(RetryResultProcessor<?>) null);
+		SubclassClassifier processors = new SubclassClassifier(map, (RetryResultProcessor<?>) null);
 		this.retryTemplate.setRetryResultProcessors(processors);
 	}
 
@@ -78,27 +71,22 @@ public class AsyncRetryTemplateTests extends AbstractAsyncRetryTest {
 			SimpleRetryPolicy policy = new SimpleRetryPolicy(x);
 			this.retryTemplate.setRetryPolicy(policy);
 			CompletableFuture<Object> result = this.retryTemplate.execute(callback);
-			assertEquals(callback.defaultResult,
-					result.get(10000L, TimeUnit.MILLISECONDS));
+			assertEquals(callback.defaultResult, result.get(10000L, TimeUnit.MILLISECONDS));
 			assertEquals(x, callback.jobAttempts.get());
 		}
 	}
 
 	// todo: remove of fix after discussion
-	/*@Test
-	public void testSuccessfulRetryFuture() throws Throwable {
-		for (int x = 1; x <= 10; x++) {
-			FutureRetryCallback callback = new FutureRetryCallback();
-			callback.setAttemptsBeforeSchedulingSuccess(1);
-			callback.setAttemptsBeforeJobSuccess(x);
-			SimpleRetryPolicy policy = new SimpleRetryPolicy(x + 1);
-			this.retryTemplate.setRetryPolicy(policy);
-			Future<Object> result = this.retryTemplate.execute(callback);
-			assertEquals(callback.defaultResult,
-					result.get(10000L, TimeUnit.MILLISECONDS));
-			assertEquals(x, callback.jobAttempts.get());
-		}
-	}*/
+	/*
+	 * @Test public void testSuccessfulRetryFuture() throws Throwable { for (int x = 1; x
+	 * <= 10; x++) { FutureRetryCallback callback = new FutureRetryCallback();
+	 * callback.setAttemptsBeforeSchedulingSuccess(1);
+	 * callback.setAttemptsBeforeJobSuccess(x); SimpleRetryPolicy policy = new
+	 * SimpleRetryPolicy(x + 1); this.retryTemplate.setRetryPolicy(policy); Future<Object>
+	 * result = this.retryTemplate.execute(callback); assertEquals(callback.defaultResult,
+	 * result.get(10000L, TimeUnit.MILLISECONDS)); assertEquals(x,
+	 * callback.jobAttempts.get()); } }
+	 */
 
 	@Test
 	public void testBackOffInvoked() throws Throwable {
@@ -111,8 +99,7 @@ public class AsyncRetryTemplateTests extends AbstractAsyncRetryTest {
 			this.retryTemplate.setRetryPolicy(policy);
 			this.retryTemplate.setBackOffPolicy(backOff);
 			CompletableFuture<Object> result = this.retryTemplate.execute(callback);
-			assertEquals(callback.defaultResult,
-					result.get(10000L, TimeUnit.MILLISECONDS));
+			assertEquals(callback.defaultResult, result.get(10000L, TimeUnit.MILLISECONDS));
 			assertEquals(x, callback.jobAttempts.get());
 			assertEquals(1, backOff.startCalls);
 			assertEquals(x - 1, backOff.backOffCalls);
@@ -133,11 +120,11 @@ public class AsyncRetryTemplateTests extends AbstractAsyncRetryTest {
 			fail("Expected IllegalArgumentException");
 		}
 		catch (ExecutionException e) {
-			assertTrue("Expected IllegalArgumentException",
-					e.getCause() instanceof IllegalArgumentException);
+			assertTrue("Expected IllegalArgumentException", e.getCause() instanceof IllegalArgumentException);
 			assertEquals(retryAttempts, callback.jobAttempts.get());
 			return;
 		}
 		fail("Expected IllegalArgumentException");
 	}
+
 }

--- a/src/test/java/org/springframework/retry/support/StatefulRecoveryRetryTests.java
+++ b/src/test/java/org/springframework/retry/support/StatefulRecoveryRetryTests.java
@@ -140,7 +140,8 @@ public class StatefulRecoveryRetryTests {
 			}
 		};
 		Object result = null;
-		// On the second retry, the recovery path is taken...
+		// The recovery path is taken just after the first attempt.
+		// No rethrow, due to no rollback is required for this type of exception.
 		result = this.retryTemplate.execute(callback, recoveryCallback, state);
 		assertEquals(input, result); // default result is the item
 		assertEquals(1, this.count);


### PR DESCRIPTION
Hello! Here is a draft for the async retry feature with rescheduling.
The goal for now is to discuss: is it worth to implement it this way.
(javadoc and formatting are expected to be later)

The general idea is described in the README.dm diff, and also is outlined here:
![async-diagram-1](https://user-images.githubusercontent.com/1533792/57971036-68624400-7991-11e9-8812-199bd08269f0.png)

**Checklist:**
- [x] solution for inter-thread retry-context propagation:
  - [x] is discussed
  - [ ] merged (+ tests)
- [ ] consensus about the value of such a feature is reached (probably, it is worth to use some full-fledged async-programming framework instead, like zio-retry for scala)
- [ ] migration of the repo to java8 is discussed and performed
- [ ] details of `java.util.concurrent.Future` support are discussed and implemented
Copy pasted from the issue:
  > Because it has no "thenApply"-like notation, exception handling and retry scheduling for actual job can not be performed by worker right after previous attempt fails, i.e. invocation of "resultFuture.get()" is required to start even the first retry of actual job. That mixes sync and async approaches in a not very beautiful way, so I propose to not specially support java.util.concurrent.Future at all. 
- [ ] javadoc and formatting are polished
- [ ] additional tests are written for:
  - [ ] stateful rescheduling
  - [ ] RejectedExecutionException on rescheduler
  - [ ] InterruptedException

**Can be done in separate PRs:**
- add ListenableFuture support
- support declarative async retry

https://github.com/spring-projects/spring-retry/issues/154