### PR TITLE
Allow composing `Retryable` annotation with other annotations

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -33,8 +33,8 @@ import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.BeanFactoryAware;
 import org.springframework.beans.factory.config.ConfigurableBeanFactory;
 import org.springframework.context.expression.BeanFactoryResolver;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.expression.common.TemplateParserContext;
 import org.springframework.expression.spel.standard.SpelExpressionParser;
 import org.springframework.expression.spel.support.StandardEvaluationContext;
@@ -163,9 +163,9 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 				}
 				Map<Method, MethodInterceptor> delegatesForTarget = this.delegates.get(target);
 				if (!delegatesForTarget.containsKey(method)) {
-					Retryable retryable = AnnotationUtils.findAnnotation(method, Retryable.class);
+					Retryable retryable = AnnotatedElementUtils.findMergedAnnotation(method, Retryable.class);
 					if (retryable == null) {
-						retryable = AnnotationUtils.findAnnotation(method.getDeclaringClass(), Retryable.class);
+						retryable = AnnotatedElementUtils.findMergedAnnotation(method.getDeclaringClass(), Retryable.class);
 					}
 					if (retryable == null) {
 						retryable = findAnnotationOnTarget(target, method);
@@ -193,9 +193,9 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 	private Retryable findAnnotationOnTarget(Object target, Method method) {
 		try {
 			Method targetMethod = target.getClass().getMethod(method.getName(), method.getParameterTypes());
-			Retryable retryable = AnnotationUtils.findAnnotation(targetMethod, Retryable.class);
+			Retryable retryable = AnnotatedElementUtils.findMergedAnnotation(targetMethod, Retryable.class);
 			if (retryable == null) {
-				retryable = AnnotationUtils.findAnnotation(targetMethod.getDeclaringClass(), Retryable.class);
+				retryable = AnnotatedElementUtils.findMergedAnnotation(targetMethod.getDeclaringClass(), Retryable.class);
 			}
 
 			return retryable;
@@ -217,7 +217,7 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 		RetryTemplate template = createTemplate(retryable.listeners());
 		template.setRetryContextCache(this.retryContextCache);
 
-		CircuitBreaker circuit = AnnotationUtils.findAnnotation(method, CircuitBreaker.class);
+		CircuitBreaker circuit = AnnotatedElementUtils.findMergedAnnotation(method, CircuitBreaker.class);
 		if (circuit != null) {
 			RetryPolicy policy = getRetryPolicy(circuit);
 			CircuitBreakerRetryPolicy breaker = new CircuitBreakerRetryPolicy(policy);
@@ -290,7 +290,7 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 		ReflectionUtils.doWithMethods(target.getClass(), new MethodCallback() {
 			@Override
 			public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
-				if (AnnotationUtils.findAnnotation(method, Recover.class) != null) {
+				if (AnnotatedElementUtils.findMergedAnnotation(method, Recover.class) != null) {
 					foundRecoverable.set(true);
 				}
 			}


### PR DESCRIPTION
Recently, i needed to combine the behavior of `@Retryable` annotation with Spring's `@Transactional` (in order to create  transactional methods that could be auto-retried in case some errors occurred).

So i created a **composed annotation** named `@RetryableTransactional`, which is defined as such:

```
/**
 * A meta-annotation that combines {@literal @}{@link Retryable} and {@literal @}{@link Transactional}.
 * 
 */
@Target({ ElementType.TYPE, ElementType.METHOD })
@Retention(RetentionPolicy.RUNTIME)
@Documented
@Retryable 
@Transactional
public @interface RetryableTransactional {

	// allow overriding attributes of @Retryable : DOEST WORK, BECAUSE OF USAGE OF AnnotationUtils.findAnnotation()
	/**
	 * @see Retryable#interceptor()
	 * @return
	 */
	@AliasFor(annotation = Retryable.class)
	String interceptor() default "";

	/**
	 * @see Retryable#include()
	 * @return
	 */
	@AliasFor(annotation = Retryable.class)
	Class<? extends Throwable>[] include() default {};

	/**
	 * @see Retryable#exclude()
	 * @return
	 */
	@AliasFor(annotation = Retryable.class)
	Class<? extends Throwable>[] exclude() default {};

	/**
	 * @see Retryable#label()
	 * @return
	 */
	@AliasFor(annotation = Retryable.class)
	String label() default "";

	/**
	 * @see Retryable#stateful()
	 * @return
	 */
	@AliasFor(annotation = Retryable.class)
	boolean stateful() default false;

	/**
	 * @see Retryable#maxAttempts()
	 * @return
	 */
	@AliasFor(annotation = Retryable.class)
	int maxAttempts() default 3;

	/**
	 * @see Retryable#maxAttemptsExpression()
	 * @return
	 */
	@AliasFor(annotation = Retryable.class)
	String maxAttemptsExpression() default "";

	/**
	 * @see Retryable#backoff()
	 * @return
	 */
	@AliasFor(annotation = Retryable.class)
	Backoff backoff() default @Backoff();

	/**
	 * @see Retryable#exceptionExpression()
	 * @return
	 */
	@AliasFor(annotation = Retryable.class)
	String exceptionExpression() default "";

	// allow overriding attributes of @Transactional:  WORKS GREAT BECAUSE OF USAGE OF `AnnotatedElementUtils.findMergedAnnotation`

	/**
	 * @see Transactional#transactionManager()
	 * @return
	 */
	@AliasFor(annotation = Transactional.class)
	String transactionManager() default "";

	/**
	 * @see Transactional#rollbackFor()
	 * @return
	 */
	@AliasFor(annotation = Transactional.class)
	Class<? extends Throwable>[] rollbackFor() default {};

	/**
	 * @see Transactional#noRollbackFor()
	 * @return
	 */
	@AliasFor(annotation = Transactional.class)
	Class<? extends Throwable>[] noRollbackFor() default {};

	/**
	 * @see Transactional#propagation()
	 * @return
	 */
	@AliasFor(annotation = Transactional.class)
	Propagation propagation() default Propagation.REQUIRED;

	/**
	 * @see Transactional#isolation()
	 * @return
	 */
	@AliasFor(annotation = Transactional.class)
	Isolation isolation() default Isolation.DEFAULT;

	/**
	 * @see Transactional#timeout()
	 * @return
	 */
	@AliasFor(annotation = Transactional.class)
	int timeout() default TransactionDefinition.TIMEOUT_DEFAULT;

	/**
	 * @see Transactional#readOnly()
	 * @return
	 */
	@AliasFor(annotation = Transactional.class)
	boolean readOnly() default false;

}
```

It works almost  great, except that because `AnnotationAwareRetryOperationsInterceptor` uses `AnnotationUtils.findAnnotation()` (instead of `AnnotatedElementUtils.findMergedAnnotation()`)
i **cannot override** the attributes of `@Retryable` part using Spring's `@AliasFor`. Instead, a default  `RetryTemplate` is created, not considering the customizations.

This commit fixes that issue and will allow future compositions of the `@Retryable` annotation.