### PR TITLE
Fix #126 clearer documentation, enforce maxInterval value, tests

### DIFF
--- a/src/main/java/org/springframework/retry/backoff/ExponentialRandomBackOffPolicy.java
+++ b/src/main/java/org/springframework/retry/backoff/ExponentialRandomBackOffPolicy.java
@@ -37,10 +37,12 @@ import java.util.Random;
  * {@link ExponentialBackOffPolicy} yields: [50, 100, 200, 400, 800]
  *
  * {@link ExponentialRandomBackOffPolicy} may yield [76, 151, 304, 580, 901] or [53, 190,
- * 267, 451, 815]
+ * 267, 451, 815] (random distributed values within the ranges of [50-100, 100-200, 200-400,
+ * 400-800, 800-1600])
  *
  * @author Jon Travis
  * @author Dave Syer
+ * @author Chase Diem
  */
 @SuppressWarnings("serial")
 public class ExponentialRandomBackOffPolicy extends ExponentialBackOffPolicy {
@@ -69,6 +71,9 @@ public class ExponentialRandomBackOffPolicy extends ExponentialBackOffPolicy {
 		public synchronized long getSleepAndIncrement() {
 			long next = super.getSleepAndIncrement();
 			next = (long) (next * (1 + r.nextFloat() * (getMultiplier() - 1)));
+			if (next > super.getMaxInterval()) {
+				next = super.getMaxInterval();
+			}
 			return next;
 		}
 

--- a/src/test/java/org/springframework/retry/backoff/ExponentialRandomBackOffPolicyTests.java
+++ b/src/test/java/org/springframework/retry/backoff/ExponentialRandomBackOffPolicyTests.java
@@ -29,6 +29,7 @@ import org.springframework.retry.support.RetrySimulator;
 /**
  * @author Dave Syer
  * @author Jon Travis
+ * @author Chase Diem
  *
  */
 public class ExponentialRandomBackOffPolicyTests {
@@ -65,6 +66,27 @@ public class ExponentialRandomBackOffPolicyTests {
 					+ initialInterval * Math.max(1, Math.pow(backOffPolicy.getMultiplier(), i)));
 			assertTrue("Found a sleep [" + sleeps.get(i) + "] which exceeds our max expected value of "
 					+ expectedMaxValue + " at interval " + i, sleeps.get(i) < expectedMaxValue);
+		}
+	}
+
+	@Test
+	public void testMaxInterval() throws Exception {
+		ExponentialBackOffPolicy backOffPolicy = makeBackoffPolicy();
+		backOffPolicy.setInitialInterval(3000);
+		long maxInterval = backOffPolicy.getMaxInterval();
+
+		RetrySimulator simulator = new RetrySimulator(backOffPolicy, makeRetryPolicy());
+		RetrySimulation simulation = simulator.executeSimulation(1);
+
+		List<Long> sleeps = simulation.getLongestTotalSleepSequence().getSleeps();
+		System.out.println("Single trial of " + backOffPolicy + ": sleeps=" + sleeps);
+		assertEquals(MAX_RETRIES - 1, sleeps.size());
+		long initialInterval = backOffPolicy.getInitialInterval();
+		for (int i = 0; i < sleeps.size(); i++) {
+			long expectedMaxValue = 2 * (long) (initialInterval
+					+ initialInterval * Math.max(1, Math.pow(backOffPolicy.getMultiplier(), i)));
+			assertTrue("Found a sleep [" + sleeps.get(i) + "] which exceeds our max interval value of "
+					+ expectedMaxValue + " at interval " + i, sleeps.get(i) <= maxInterval);
 		}
 	}
 


### PR DESCRIPTION
Fix #126 -- Clearer documentation on what ranges are possible in the example, check to enforce maxInterval so the random multiplication step cannot exceed it.

Pivotal CLI signed for a previous Spring project. Contribution on behalf of Comcast Corporation.

Contribution on behalf of Comcast Corporation.