### PR TITLE
Allow recover by name in `Retryable` annotation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,25 +481,24 @@ The following example shows how to do so:
 
 ```java
 @Service
-class Service {
-
+class Service { 
     @Retryable(recover = "service1Recover", value = RemoteAccessException.class)
-	public void service1(String str1, String str2) {
+    public void service1(String str1, String str2) {
         // ... do something
     }
 
     @Retryable(recover = "service2Recover", value = RemoteAccessException.class)
-	public void service2(String str1, String str2) {
+    public void service2(String str1, String str2) {
         // ... do something
     }
 
     @Recover
-	public void service1Recover(RemoteAccessException e, String str1, String str2) {
+    public void service1Recover(RemoteAccessException e, String str1, String str2) {
         // ... error handling making use of original args if required
     }
 
     @Recover
-	public void service2Recover(RemoteAccessException e, String str1, String str2) {
+    public void service2Recover(RemoteAccessException e, String str1, String str2) {
         // ... error handling making use of original args if required
     }
 }

--- a/README.md
+++ b/README.md
@@ -486,13 +486,11 @@ class Service {
     @Retryable(recover = "service1Recover", value = RemoteAccessException.class)
 	public void service1(String str1, String str2) {
         // ... do something
-		throw new RemoteAccessException("");
     }
 
     @Retryable(recover = "service2Recover", value = RemoteAccessException.class)
 	public void service2(String str1, String str2) {
         // ... do something
-		throw new RemoteAccessException("");
     }
 
     @Recover

--- a/README.md
+++ b/README.md
@@ -476,6 +476,37 @@ class Service {
 }
 ```
 
+To resolve conflicts between multiple methods that can be picked for recovery. You can explicitly specify recovery method name. 
+The following example shows how to do so:
+
+```java
+@Service
+class Service {
+
+    @Retryable(recover = "service1Recover", value = RemoteAccessException.class)
+	public void service1(String str1, String str2) {
+        // ... do something
+		throw new RemoteAccessException("");
+    }
+
+    @Retryable(recover = "service2Recover", value = RemoteAccessException.class)
+	public void service2(String str1, String str2) {
+        // ... do something
+		throw new RemoteAccessException("");
+    }
+
+    @Recover
+	public void service1Recover(RemoteAccessException e, String str1, String str2) {
+        // ... error handling making use of original args if required
+    }
+
+    @Recover
+	public void service2Recover(RemoteAccessException e, String str1, String str2) {
+        // ... error handling making use of original args if required
+    }
+}
+```
+
 Version 1.2 introduces the ability to use expressions for certain properties. The
 following example show how to use expressions this way:
 

--- a/src/main/java/org/springframework/retry/annotation/Recover.java
+++ b/src/main/java/org/springframework/retry/annotation/Recover.java
@@ -42,11 +42,4 @@ import org.springframework.context.annotation.Import;
 @Documented
 public @interface Recover {
 
-	/**
-	 * Name of this function can be used to provide best match for recoverName in
-	 * Retryable. {@link Retryable#recoverName()}
-	 * @return name of this recover function
-	 */
-	String name() default "";
-
 }

--- a/src/main/java/org/springframework/retry/annotation/Recover.java
+++ b/src/main/java/org/springframework/retry/annotation/Recover.java
@@ -42,4 +42,11 @@ import org.springframework.context.annotation.Import;
 @Documented
 public @interface Recover {
 
+	/**
+	 * Name of this function can be used to provide best match for recoverName in
+	 * Retryable. {@link Retryable#recoverName()}
+	 * @return name of this recover function
+	 */
+	String name() default "";
+
 }

--- a/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
+++ b/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
@@ -88,11 +88,13 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 		boolean shouldUseRecoverMethodName = !this.recoverMethodName.equals("");
 		if (shouldUseRecoverMethodName) {
 			for (Method method : this.methods.keySet()) {
-				SimpleMetadata meta = this.methods.get(method);
-				if (meta.getName().equals(this.recoverMethodName) && meta.type.isAssignableFrom(cause)
-						&& compareParameters(args, meta.getArgCount(), method.getParameterTypes())) {
-					result = method;
-					break;
+				if (method.getName().equals(this.recoverMethodName)) {
+					SimpleMetadata meta = this.methods.get(method);
+					if (meta.type.isAssignableFrom(cause)
+							&& compareParameters(args, meta.getArgCount(), method.getParameterTypes())) {
+						result = method;
+						break;
+					}
 				}
 			}
 		}
@@ -164,18 +166,17 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 				Recover recover = AnnotationUtils.findAnnotation(method, Recover.class);
 				if (recover != null && method.getReturnType().isAssignableFrom(failingMethod.getReturnType())) {
 					Class<?>[] parameterTypes = method.getParameterTypes();
-					String functionName = !recover.name().equals("") ? recover.name() : method.getName();
 					if (parameterTypes.length > 0 && Throwable.class.isAssignableFrom(parameterTypes[0])) {
 						@SuppressWarnings("unchecked")
 						Class<? extends Throwable> type = (Class<? extends Throwable>) parameterTypes[0];
 						types.put(type, method);
 						RecoverAnnotationRecoveryHandler.this.methods.put(method,
-								new SimpleMetadata(parameterTypes.length, type, functionName));
+								new SimpleMetadata(parameterTypes.length, type));
 					}
 					else {
 						RecoverAnnotationRecoveryHandler.this.classifier.setDefaultValue(method);
 						RecoverAnnotationRecoveryHandler.this.methods.put(method,
-								new SimpleMetadata(parameterTypes.length, null, functionName));
+								new SimpleMetadata(parameterTypes.length, null));
 					}
 				}
 			}
@@ -202,21 +203,14 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 
 		private Class<? extends Throwable> type;
 
-		private String name;
-
-		public SimpleMetadata(int argCount, Class<? extends Throwable> type, String name) {
+		public SimpleMetadata(int argCount, Class<? extends Throwable> type) {
 			super();
 			this.argCount = argCount;
 			this.type = type;
-			this.name = name;
 		}
 
 		public int getArgCount() {
 			return this.argCount;
-		}
-
-		public String getName() {
-			return this.name;
 		}
 
 		public Class<? extends Throwable> getType() {

--- a/src/main/java/org/springframework/retry/annotation/Retryable.java
+++ b/src/main/java/org/springframework/retry/annotation/Retryable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014 the original author or authors.
+ * Copyright 2014-2019 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -28,6 +28,7 @@ import java.lang.annotation.Target;
  * @author Dave Syer
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Maksim Kita
  * @since 1.1
  *
  */
@@ -37,10 +38,10 @@ import java.lang.annotation.Target;
 public @interface Retryable {
 
 	/**
-	 * Name of function to use for recover.
-	 * @return the name of retry function to use
+	 * Name of method in this class to use for recover.
+	 * @return the name of recover method
 	 */
-	String recoverName() default "";
+	String recover() default "";
 
 	/**
 	 * Retry interceptor bean name to be applied for retryable method. Is mutually

--- a/src/main/java/org/springframework/retry/annotation/Retryable.java
+++ b/src/main/java/org/springframework/retry/annotation/Retryable.java
@@ -38,7 +38,8 @@ import java.lang.annotation.Target;
 public @interface Retryable {
 
 	/**
-	 * Name of method in this class to use for recover. Method had to be marked with {@link Recover} annotation.
+	 * Name of method in this class to use for recover.
+	 * Method had to be marked with {@link Recover} annotation.
 	 * @return the name of recover method
 	 */
 	String recover() default "";

--- a/src/main/java/org/springframework/retry/annotation/Retryable.java
+++ b/src/main/java/org/springframework/retry/annotation/Retryable.java
@@ -37,6 +37,12 @@ import java.lang.annotation.Target;
 public @interface Retryable {
 
 	/**
+	 * Name of function to use for recover.
+	 * @return the name of retry function to use
+	 */
+	String recoverName() default "";
+
+	/**
 	 * Retry interceptor bean name to be applied for retryable method. Is mutually
 	 * exclusive with other attributes.
 	 * @return the retry interceptor bean name

--- a/src/main/java/org/springframework/retry/annotation/Retryable.java
+++ b/src/main/java/org/springframework/retry/annotation/Retryable.java
@@ -38,7 +38,7 @@ import java.lang.annotation.Target;
 public @interface Retryable {
 
 	/**
-	 * Name of method in this class to use for recover.
+	 * Name of method in this class to use for recover. Method had to be marked with {@link Recover} annotation.
 	 * @return the name of recover method
 	 */
 	String recover() default "";

--- a/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
@@ -161,6 +161,22 @@ public class RecoverAnnotationRecoveryHandlerTests {
 				handler.recover(new Object[] { new ArrayList<String>() }, new IllegalArgumentException("Planned")));
 	}
 
+	@Test
+	public void recoverByRetryableNameWithoutRecoverName() {
+		Method foo = ReflectionUtils.findMethod(RecoverByRetryableNameWithoutRecoverName.class, "foo", String.class);
+		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
+				new RecoverByRetryableNameWithoutRecoverName(), foo);
+		assertEquals(2, handler.recover(new Object[] { "Kevin" }, new RuntimeException("Planned")));
+	}
+
+	@Test
+	public void recoverByRetryableNameAndRecoverName() {
+		Method foo = ReflectionUtils.findMethod(RecoverByRetryableNameAndRecoverName.class, "foo", String.class);
+		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
+				new RecoverByRetryableNameAndRecoverName(), foo);
+		assertEquals(3, handler.recover(new Object[] { "Kevin" }, new RuntimeException("Planned")));
+	}
+
 	private static class InAccessibleRecover {
 
 		@Retryable
@@ -390,6 +406,49 @@ public class RecoverAnnotationRecoveryHandlerTests {
 		@Recover
 		public int barRecover(Throwable t, String name) {
 			return 2;
+		}
+
+	}
+
+	protected static class RecoverByRetryableNameWithoutRecoverName {
+
+		@Retryable(recoverName = "barRecover")
+		public int foo(String name) {
+			return 0;
+		}
+
+		@Recover
+		public int fooRecover(Throwable throwable, String name) {
+			return 1;
+		}
+
+		@Recover
+		public int barRecover(Throwable throwable, String name) {
+			return 2;
+		}
+
+	}
+
+	protected static class RecoverByRetryableNameAndRecoverName {
+
+		@Retryable(recoverName = "recoverFromFoo")
+		public int foo(String name) {
+			return 0;
+		}
+
+		@Recover
+		public int fooRecover(Throwable throwable, String name) {
+			return 1;
+		}
+
+		@Recover
+		public int barRecover(Throwable throwable, String name) {
+			return 2;
+		}
+
+		@Recover(name = "recoverFromFoo")
+		public int recover(Throwable throwable, String name) {
+			return 3;
 		}
 
 	}

--- a/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
@@ -162,19 +162,11 @@ public class RecoverAnnotationRecoveryHandlerTests {
 	}
 
 	@Test
-	public void recoverByRetryableNameWithoutRecoverName() {
-		Method foo = ReflectionUtils.findMethod(RecoverByRetryableNameWithoutRecoverName.class, "foo", String.class);
+	public void recoverByRetryableName() {
+		Method foo = ReflectionUtils.findMethod(RecoverByRetryableName.class, "foo", String.class);
 		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
-				new RecoverByRetryableNameWithoutRecoverName(), foo);
+				new RecoverByRetryableName(), foo);
 		assertEquals(2, handler.recover(new Object[] { "Kevin" }, new RuntimeException("Planned")));
-	}
-
-	@Test
-	public void recoverByRetryableNameAndRecoverName() {
-		Method foo = ReflectionUtils.findMethod(RecoverByRetryableNameAndRecoverName.class, "foo", String.class);
-		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
-				new RecoverByRetryableNameAndRecoverName(), foo);
-		assertEquals(3, handler.recover(new Object[] { "Kevin" }, new RuntimeException("Planned")));
 	}
 
 	private static class InAccessibleRecover {
@@ -410,7 +402,7 @@ public class RecoverAnnotationRecoveryHandlerTests {
 
 	}
 
-	protected static class RecoverByRetryableNameWithoutRecoverName {
+	protected static class RecoverByRetryableName {
 
 		@Retryable(recoverName = "barRecover")
 		public int foo(String name) {
@@ -425,30 +417,6 @@ public class RecoverAnnotationRecoveryHandlerTests {
 		@Recover
 		public int barRecover(Throwable throwable, String name) {
 			return 2;
-		}
-
-	}
-
-	protected static class RecoverByRetryableNameAndRecoverName {
-
-		@Retryable(recoverName = "recoverFromFoo")
-		public int foo(String name) {
-			return 0;
-		}
-
-		@Recover
-		public int fooRecover(Throwable throwable, String name) {
-			return 1;
-		}
-
-		@Recover
-		public int barRecover(Throwable throwable, String name) {
-			return 2;
-		}
-
-		@Recover(name = "recoverFromFoo")
-		public int recover(Throwable throwable, String name) {
-			return 3;
 		}
 
 	}

--- a/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertEquals;
  * @author Aldo Sinanaj
  * @author Randell Callahan
  * @author Nathanaël Roberts
+ * @author Maksim Kita
  */
 public class RecoverAnnotationRecoveryHandlerTests {
 
@@ -404,7 +405,7 @@ public class RecoverAnnotationRecoveryHandlerTests {
 
 	protected static class RecoverByRetryableName {
 
-		@Retryable(recoverName = "barRecover")
+		@Retryable(recover = "barRecover")
 		public int foo(String name) {
 			return 0;
 		}


### PR DESCRIPTION
> Why not introduce a recoveryName attribute in the `@Retry(recoverName="recover1")` annotation that can then be matched in the `@Recover(name="recover1"...)` annotation? Using parameter names gets super confusing and isn't clear, which forces developers to have to do more testing of the framework just to ensure they have set it up right.
https://github.com/spring-projects/spring-retry/issues/85

**Examples of usage**

``` java
protected static class RecoverByRetryableName {

	@Retryable(recoverName = "barRecover")
	public int foo(String name) {
		return 0;
	}

	@Recover
	public int fooRecover(Throwable throwable, String name) {
		return 1;
	}

	@Recover
	public int barRecover(Throwable throwable, String name) {
		return 2;
	}
}
```

**Current implementation steps**
1.  Added recover name in Retryable annotation.
3. Updated tests.
<!-- end list -->

**To be done before merge**
1. Update Readme
1. Update javadoc
<!-- end list -->
