### PR TITLE
Support @Recovery method that is not defined in interface

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
+++ b/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
@@ -166,7 +166,7 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 		if (retryable != null) {
 			this.recoverMethodName = retryable.recover();
 		}
-		ReflectionUtils.doWithMethods(failingMethod.getDeclaringClass(), new MethodCallback() {
+		ReflectionUtils.doWithMethods(target.getClass(), new MethodCallback() {
 			@Override
 			public void doWith(Method method) throws IllegalArgumentException, IllegalAccessException {
 				Recover recover = AnnotationUtils.findAnnotation(method, Recover.class);

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
@@ -182,6 +182,14 @@ public class EnableRetryTests {
 	}
 
 	@Test
+	public void testInterfaceWithNoRecover() {
+		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestConfiguration.class);
+		NoRecoverInterface service = context.getBean(NoRecoverInterface.class);
+		service.service();
+		assertTrue(service.isRecovered());
+	}
+
+	@Test
 	public void testImplementation() {
 		AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(TestConfiguration.class);
 		NotAnnotatedInterface service = context.getBean(NotAnnotatedInterface.class);
@@ -349,6 +357,11 @@ public class EnableRetryTests {
 		@Bean
 		public TheInterface anInterface() {
 			return new TheClass();
+		}
+
+		@Bean
+		public NoRecoverInterface anInterfaceWithNoRecover() {
+			return new NoRecoverClass();
 		}
 
 		@Bean
@@ -635,6 +648,32 @@ public class EnableRetryTests {
 			return this.recovered;
 		}
 
+	}
+
+	public static interface NoRecoverInterface {
+		void service();
+		boolean isRecovered();
+	}
+
+	public static class NoRecoverClass implements NoRecoverInterface {
+
+		private boolean recovered;
+
+		@Override
+		@Retryable
+		public void service() {
+			throw new RuntimeException("Planned");
+		}
+
+		@Recover
+		public void recover(Exception e) {
+			this.recovered = true;
+		}
+
+		@Override
+		public boolean isRecovered() {
+			return this.recovered;
+		}
 	}
 
 	public static interface NotAnnotatedInterface {


### PR DESCRIPTION
Fixes #197. Even with the changes from #124, recovery methods that are not defined in the interface are not found. I've tested my suggested change, replacing `failingMethod.getDeclaringClass()` with `target.getClass()`. No unit tests failed with this change 🤞.