### PR TITLE
Use AnnotationUtils for retryable name

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
+++ b/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
@@ -162,7 +162,7 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 	private void init(final Object target, Method method) {
 		final Map<Class<? extends Throwable>, Method> types = new HashMap<Class<? extends Throwable>, Method>();
 		final Method failingMethod = method;
-		Retryable retryable = method.getAnnotation(Retryable.class);
+		Retryable retryable = AnnotationUtils.findAnnotation(method, Retryable.class);
 		if (retryable != null) {
 			this.recoverMethodName = retryable.recover();
 		}

--- a/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
@@ -403,23 +403,32 @@ public class RecoverAnnotationRecoveryHandlerTests {
 
 	}
 
-	protected static class RecoverByRetryableName {
+	protected static class RecoverByRetryableName implements  RecoverByRetryableNameInterface{
 
-		@Retryable(recover = "barRecover")
 		public int foo(String name) {
 			return 0;
 		}
 
-		@Recover
 		public int fooRecover(Throwable throwable, String name) {
 			return 1;
 		}
 
-		@Recover
 		public int barRecover(Throwable throwable, String name) {
 			return 2;
 		}
 
 	}
 
+	protected interface RecoverByRetryableNameInterface {
+
+		@Retryable(recover = "barRecover")
+		public int foo(String name);
+
+		@Recover
+		public int fooRecover(Throwable throwable, String name);
+
+		@Recover
+		public int barRecover(Throwable throwable, String name);
+
+	}
 }


### PR DESCRIPTION
This allows for the annotations to be used on an interface and still be able to get the retryable name for the failure method.