### PR TITLE
Let build fail for failing tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,6 @@
 	</licenses>
 	<packaging>jar</packaging>
 	<properties>
-		<maven.test.failure.ignore>true</maven.test.failure.ignore>
 		<spring.framework.version>4.3.22.RELEASE</spring.framework.version>
 		<disable.checks>false</disable.checks>
 	</properties>
@@ -72,12 +71,6 @@
 					</snapshots>
 				</pluginRepository>
 			</pluginRepositories>
-		</profile>
-		<profile>
-			<id>strict</id>
-			<properties>
-				<maven.test.failure.ignore>false</maven.test.failure.ignore>
-			</properties>
 		</profile>
 		<profile>
 			<id>fast</id>

--- a/src/test/java/org/springframework/retry/annotation/ProxyApplicationTests.java
+++ b/src/test/java/org/springframework/retry/annotation/ProxyApplicationTests.java
@@ -1,6 +1,5 @@
 package org.springframework.retry.annotation;
 
-import java.net.URLClassLoader;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.Set;
@@ -53,7 +52,7 @@ public class ProxyApplicationTests {
 	}
 
 	private int count() {
-		URLClassLoader classLoader = (URLClassLoader) getClass().getClassLoader();
+		ClassLoader classLoader = getClass().getClassLoader();
 		@SuppressWarnings("unchecked")
 		Vector<Class<?>> classes = (Vector<Class<?>>) ReflectionTestUtils.getField(classLoader, "classes");
 		Set<Class<?>> news = new HashSet<Class<?>>();


### PR DESCRIPTION
fixes https://github.com/spring-projects/spring-retry/issues/198
and resolves `ClassCastException` in `ProxyApplicationTests`