### PR TITLE
GH-244: Invoke Proxy for @Recover Method

### DIFF
--- a/src/main/java/org/springframework/retry/interceptor/RetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/interceptor/RetryOperationsInterceptor.java
@@ -118,12 +118,16 @@ public class RetryOperationsInterceptor implements MethodInterceptor {
 		if (this.recoverer != null) {
 			ItemRecovererCallback recoveryCallback = new ItemRecovererCallback(invocation.getArguments(),
 					this.recoverer);
-			Object recovered = this.retryOperations.execute(retryCallback, recoveryCallback);
-			RetryContext context = RetrySynchronizationManager.getContext();
-			if (context != null) {
-				context.removeAttribute("__proxy__");
+			try {
+				Object recovered = this.retryOperations.execute(retryCallback, recoveryCallback);
+				return recovered;
 			}
-			return recovered;
+			finally {
+				RetryContext context = RetrySynchronizationManager.getContext();
+				if (context != null) {
+					context.removeAttribute("__proxy__");
+				}
+			}
 		}
 
 		return this.retryOperations.execute(retryCallback);


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-retry/issues/244

The `RecoverAnnotationRecoveryHandler` only has access to the undecorated
raw bean.

Use the `RetryContext` to make the proxy (if CGLIB) available to the recoverer.