### PR TITLE
GH-214: Retryable on JPA Repos with proxyTargetClass [DO NOT MERGE]

### DIFF
--- a/README.md
+++ b/README.md
@@ -596,6 +596,13 @@ line  to your `build.gradle` file:
     runtime('org.aspectj:aspectjweaver:1.8.13')
 ```
 
+### Using Declarative Retry on Spring JPA Repository Interfaces
+
+When using Spring Spring Boot, to enable support for adding `@Retryable` to JPA Repository Interface methods, you can add
+a `JPARepositoryRetryBeanPostProcessor` to the application context, or set the [spring.aop.proxy-target-class](https://docs.spring.io/spring-boot/docs/current/reference/html/application-properties.html#application-properties.core.spring.aop.proxy-target-class) property to `false`.
+When this property is true, it prevents the auto-proxy mechanism from copying the repository interfaces to the retry proxy.
+Adding the bean post processor causes a new proxy to be created, merging the interfaces and advisors on the JPA and retry proxies.
+
 ### XML Configuration
 
 The following example of declarative iteration uses Spring AOP to repeat a service call to

--- a/pom.xml
+++ b/pom.xml
@@ -276,6 +276,12 @@
 			<version>1.2.17</version>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.data</groupId>
+			<artifactId>spring-data-jpa</artifactId>
+			<version>2.5.1</version>
+			<optional>true</optional>
+		</dependency>
 	</dependencies>
 
 	<reporting>

--- a/src/main/java/org/springframework/retry/annotation/JPARepositoryRetryBeanPostProcessor.java
+++ b/src/main/java/org/springframework/retry/annotation/JPARepositoryRetryBeanPostProcessor.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.annotation;
+
+import org.springframework.aop.Advisor;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.framework.ProxyFactory;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.core.Ordered;
+import org.springframework.data.jpa.repository.support.JpaRepositoryImplementation;
+import org.springframework.retry.interceptor.Retryable;
+
+/**
+ * Add a bean of this instance if you wish to annotate JPA Repository interfaces with
+ * {@code @Retryable}. It merges the repository proxy advisors with the retry advisor.
+ *
+ * @author Gary Russell
+ * @since 1.3.2
+ */
+public class JPARepositoryRetryBeanPostProcessor implements BeanPostProcessor, Ordered {
+
+	@Override
+	public int getOrder() {
+		return Integer.MAX_VALUE;
+	}
+
+	@Override
+	public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+		if (bean instanceof Retryable && bean instanceof Advised) {
+			Advised advised = (Advised) bean;
+			try {
+				Object target = advised.getTargetSource().getTarget();
+				if (target instanceof Advised) {
+					Advised advised2 = (Advised) target;
+					Object target2 = advised2.getTargetSource().getTarget();
+					if (target2 != null) {
+						ProxyFactory pf = new ProxyFactory(target2);
+						pf.removeInterface(JpaRepositoryImplementation.class);
+						for (Advisor advisor : advised.getAdvisors()) {
+							pf.addAdvisor(advisor);
+						}
+						for (Advisor advisor : advised2.getAdvisors()) {
+							pf.addAdvisor(advisor);
+						}
+						for (Class<?> iface : advised2.getProxiedInterfaces()) {
+							pf.addInterface(iface);
+						}
+						return pf.getProxy();
+					}
+				}
+			}
+			catch (Exception e) {
+				e.printStackTrace();
+			}
+		}
+		return bean;
+	}
+
+	@Override
+	public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+		return bean;
+	}
+
+}

--- a/src/main/java/org/springframework/retry/annotation/RetryConfiguration.java
+++ b/src/main/java/org/springframework/retry/annotation/RetryConfiguration.java
@@ -231,7 +231,8 @@ public class RetryConfiguration extends AbstractPointcutAdvisor
 
 		@Override
 		public boolean matches(Class<?> clazz) {
-			return super.matches(clazz) || this.methodResolver.hasAnnotatedMethods(clazz);
+			return "org.springframework.data.jpa.repository.support.SimpleJpaRepository".equals(clazz.getName())
+					|| super.matches(clazz) || this.methodResolver.hasAnnotatedMethods(clazz);
 		}
 
 	}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-retry/issues/214

When `proxyTargetClass` is `true` (Boot's default), the JPA interfaces
are not copied to the outer retry proxy created by auto-proxy.

Add a BPP to fix up the proxy, when needed.

Also, the pointcut filter must match on the `SimpleJpaRepository`.