### PR TITLE
Allow primitive type for @Recover method parameter

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
+++ b/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
@@ -52,6 +52,19 @@ import org.springframework.util.StringUtils;
  */
 public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationRecoverer<T> {
 
+	private final static Map<Class<?>, Class<?>> wrappers = new HashMap<>();
+
+	static {
+		wrappers.put(boolean.class, Boolean.class);
+		wrappers.put(byte.class, Byte.class);
+		wrappers.put(short.class, Short.class);
+		wrappers.put(char.class, Character.class);
+		wrappers.put(int.class, Integer.class);
+		wrappers.put(long.class, Long.class);
+		wrappers.put(float.class, Float.class);
+		wrappers.put(double.class, Double.class);
+	}
+
 	private SubclassClassifier<Throwable, Method> classifier = new SubclassClassifier<Throwable, Method>();
 
 	private Map<Method, SimpleMetadata> methods = new HashMap<Method, SimpleMetadata>();
@@ -152,7 +165,9 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 				if (argument == null) {
 					continue;
 				}
-				if (!parameterTypes[i].isAssignableFrom(argument.getClass())) {
+				Class<?> parameterType = parameterTypes[i];
+				parameterType = parameterType.isPrimitive() ? wrappers.get(parameterType) : parameterType;
+				if (!parameterType.isAssignableFrom(argument.getClass())) {
 					return false;
 				}
 			}

--- a/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
@@ -275,6 +275,14 @@ public class RecoverAnnotationRecoveryHandlerTests {
 		assertEquals(2, handler.recover(new Object[] { "Kevin" }, new RuntimeException("Planned")));
 	}
 
+    @Test
+    public void recoverByRetryableNameWithPrimitiveArgs() {
+        Method foo = ReflectionUtils.findMethod(RecoverByRetryableNameWithPrimitiveArgs.class, "foo", int.class);
+        RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
+            new RecoverByRetryableNameWithPrimitiveArgs(), foo);
+        assertEquals(2, handler.recover(new Object[] { 2 }, new RuntimeException("Planned")));
+    }
+
 	private static class InAccessibleRecover {
 
 		@Retryable
@@ -644,4 +652,32 @@ public class RecoverAnnotationRecoveryHandlerTests {
 
 	}
 
+    protected static class RecoverByRetryableNameWithPrimitiveArgs implements RecoverByRetryableNameWithPrimitiveArgsInterface {
+
+        public int foo(int number) {
+            return 0;
+        }
+
+        public int fooRecover(Throwable throwable, int number) {
+            return 0;
+        }
+
+        public int barRecover(Throwable throwable, int number) {
+            return number;
+        }
+
+    }
+
+    protected interface RecoverByRetryableNameWithPrimitiveArgsInterface {
+
+        @Retryable(recover = "barRecover")
+        public int foo(int number);
+
+        @Recover
+        public int fooRecover(Throwable throwable, int number);
+
+        @Recover
+        public int barRecover(Throwable throwable, int number);
+
+    }
 }


### PR DESCRIPTION
I want to use the primitive type when I specify the Recover method.

But I could only use the wrapped type like below and I simply fixed this part.

I simply fixed this part, so I think you can fix it a better.

Thank you.

```java
@Retryable(recover = "barRecover")
public int foo(int number);

@Recover
public int fooRecover(Throwable throwable, Integer number);

@Recover
public int barRecover(Throwable throwable, Integer number);
```