### PR TITLE
Remove Maven warnings

### DIFF
--- a/.springjavaformatconfig
+++ b/.springjavaformatconfig
@@ -1,0 +1,1 @@
+java-baseline=8

--- a/pom.xml
+++ b/pom.xml
@@ -97,9 +97,10 @@
 			<build>
 				<plugins>
 					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
 						<artifactId>maven-javadoc-plugin</artifactId>
 						<configuration>
-							<additionalparam>-Xdoclint:none</additionalparam>
+							<doclint>none</doclint>
 						</configuration>
 					</plugin>
 				</plugins>
@@ -301,15 +302,29 @@
 		<pluginManagement>
 			<plugins>
 				<plugin>
+					<groupId>io.spring.javaformat</groupId>
+					<artifactId>spring-javaformat-maven-plugin</artifactId>
+					<version>0.0.31</version>
+				</plugin>
+				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
-					<artifactId>maven-site-plugin</artifactId>
-					<dependencies>
-						<dependency>
-							<groupId>org.apache.maven.wagon</groupId>
-							<artifactId>wagon-ssh</artifactId>
-							<version>2.0</version>
-						</dependency>
-					</dependencies>
+					<artifactId>maven-assembly-plugin</artifactId>
+					<version>3.3.0</version>
+					<configuration>
+						<descriptorRefs>
+							<descriptorRef>project</descriptorRef>
+						</descriptorRefs>
+					</configuration>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-compiler-plugin</artifactId>
+					<version>3.9.0</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-javadoc-plugin</artifactId>
+					<version>3.3.1</version>
 				</plugin>
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
@@ -317,13 +332,14 @@
 					<version>2.5</version>
 				</plugin>
 				<plugin>
-					<artifactId>maven-assembly-plugin</artifactId>
-					<inherited>false</inherited>
-					<configuration>
-						<descriptorRefs>
-							<descriptorRef>project</descriptorRef>
-						</descriptorRefs>
-					</configuration>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-source-plugin</artifactId>
+					<version>3.2.1</version>
+				</plugin>
+				<plugin>
+					<groupId>org.apache.maven.plugins</groupId>
+					<artifactId>maven-surefire-plugin</artifactId>
+					<version>2.22.1</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>
@@ -339,7 +355,6 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.22.1</version>
 				<configuration>
 					<!--forkMode>pertest</forkMode -->
 					<includes>
@@ -351,6 +366,7 @@
 				</configuration>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
 				<executions>
 					<execution>
@@ -363,6 +379,7 @@
 				</executions>
 			</plugin>
 			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
 				<executions>
 					<execution>


### PR DESCRIPTION
This commit removes the warnings that Maven emits when building the
effective model of the project. This boils down to locking down plugin
versions.

Because there is no version for javaformat, Maven could decide to use
the latest, which requires extra care to build with Java 8. This commit
upgrades explicitly to the latest and configure it to be compatible
with Java 8