### PR TITLE
Do not apply Javaformat by default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -381,7 +381,6 @@
 								<skip>${disable.checks}</skip>
 							</configuration>
 							<goals>
-								<goal>apply</goal>
 								<goal>validate</goal>
 							</goals>
 						</execution>

--- a/src/main/java/org/springframework/retry/annotation/Backoff.java
+++ b/src/main/java/org/springframework/retry/annotation/Backoff.java
@@ -117,9 +117,10 @@ public @interface Backoff {
 	boolean random() default false;
 
 	/**
-	 * Evaluates to a value. In the exponential case ({@link #multiplier()} &gt; 0) set this to true to have the
-	 * backoff delays randomized, so that the maximum delay is multiplier times the
-	 * previous delay and the distribution is uniform between the two values.
+	 * Evaluates to a value. In the exponential case ({@link #multiplier()} &gt; 0) set
+	 * this to true to have the backoff delays randomized, so that the maximum delay is
+	 * multiplier times the previous delay and the distribution is uniform between the two
+	 * values.
 	 * @return the flag to signal randomization is required (default false)
 	 */
 	String randomExpression() default "";


### PR DESCRIPTION
This PR removes the invocation of spring-javaformat:apply by default. Doing so makes the validate goal irrelevant as apply is going to reformat the code if necessary.

The idea of the plugin is that it should prevent you from pushing something that has formatting violations. Running the build, run the apply goal manually, and amending the commit is the idiomatic way of using this plugin.