### PR TITLE
Move CI to Concourse

### DIFF
--- a/ci/README.adoc
+++ b/ci/README.adoc
@@ -1,0 +1,18 @@
+== Concourse pipeline
+
+Ensure that you've setup the target and can login
+
+[source]
+----
+$ fly -t spring-retry login -n spring-retry -c https://ci.spring.io
+----
+
+The pipeline can be deployed using the following command:
+
+[source]
+----
+$ fly -t spring-retry set-pipeline -p spring-retry-1.3.x -c ci/pipeline.yml -l ci/parameters.yml
+----
+
+NOTE: This assumes that you have credhub integration configured with the appropriate
+secrets.

--- a/ci/config/changelog-generator.yml
+++ b/ci/config/changelog-generator.yml
@@ -1,0 +1,16 @@
+changelog:
+  repository: spring-projects/spring-retry
+  sections:
+    - title: ":star: New Features"
+      labels:
+        - "enhancement"
+    - title: ":lady_beetle: Bug Fixes"
+      labels:
+        - "bug"
+    - title: ":notebook_with_decorative_cover: Documentation"
+      labels:
+        - "documentation"
+    - title: ":hammer: Dependency Upgrades"
+      sort: "title"
+      labels:
+        - "dependencies"

--- a/ci/config/release-scripts.yml
+++ b/ci/config/release-scripts.yml
@@ -1,0 +1,10 @@
+logging:
+  level:
+    io.spring.concourse: DEBUG
+spring:
+  main:
+    banner-mode: off
+sonatype:
+  exclude:
+    - 'build-info\.json'
+    - '.*\.zip'

--- a/ci/images/README.adoc
+++ b/ci/images/README.adoc
@@ -1,0 +1,21 @@
+== CI Images
+
+These images are used by CI to run the actual builds.
+
+To build the image locally run the following from this directory:
+
+----
+$ docker build --no-cache -f <image-folder>/Dockerfile .
+----
+
+For example
+
+----
+$ docker build --no-cache -f ci-image/Dockerfile .
+----
+
+To test run:
+
+----
+$ docker run -it --entrypoint /bin/bash <SHA>
+----

--- a/ci/images/ci-image/Dockerfile
+++ b/ci/images/ci-image/Dockerfile
@@ -1,0 +1,8 @@
+FROM ubuntu:focal-20220113
+
+ADD setup.sh /setup.sh
+ADD get-jdk-url.sh /get-jdk-url.sh
+RUN ./setup.sh java8
+
+ENV JAVA_HOME /opt/openjdk
+ENV PATH $JAVA_HOME/bin:$PATH

--- a/ci/images/get-jdk-url.sh
+++ b/ci/images/get-jdk-url.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+case "$1" in
+	java8)
+		 echo "https://github.com/adoptium/temurin8-binaries/releases/download/jdk8u322-b06/OpenJDK8U-jdk_x64_linux_hotspot_8u322b06.tar.gz"
+	;;
+	*)
+		echo $"Unknown java version"
+		exit 1
+esac

--- a/ci/images/setup.sh
+++ b/ci/images/setup.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -ex
+
+###########################################################
+# UTILS
+###########################################################
+
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install --no-install-recommends -y tzdata ca-certificates net-tools libxml2-utils git curl libudev1 libxml2-utils iptables iproute2 jq unzip
+ln -fs /usr/share/zoneinfo/UTC /etc/localtime
+dpkg-reconfigure --frontend noninteractive tzdata
+rm -rf /var/lib/apt/lists/*
+
+curl https://raw.githubusercontent.com/spring-io/concourse-java-scripts/v0.0.4/concourse-java.sh > /opt/concourse-java.sh
+
+curl --output /opt/concourse-release-scripts.jar https://repo.spring.io/release/io/spring/concourse/releasescripts/concourse-release-scripts/0.3.2/concourse-release-scripts-0.3.2.jar
+
+###########################################################
+# JAVA
+###########################################################
+JDK_URL=$( ./get-jdk-url.sh $1 )
+
+mkdir -p /opt/openjdk
+cd /opt/openjdk
+curl -L ${JDK_URL} | tar zx --strip-components=1
+test -f /opt/openjdk/bin/java
+test -f /opt/openjdk/bin/javac

--- a/ci/parameters.yml
+++ b/ci/parameters.yml
@@ -1,0 +1,12 @@
+github-repo: "https://github.com/spring-projects/spring-retry.git"
+github-repo-name: "spring-projects/spring-retry"
+docker-hub-organization: "springci"
+artifactory-server: "https://repo.spring.io"
+branch: "main"
+milestone: "1.3.x"
+build-name: "spring-retry"
+concourse-url: "https://ci.spring.io"
+task-timeout: 30m
+registry-mirror-host: docker.repo.spring.io
+registry-mirror-username: ((artifactory-username))
+registry-mirror-password: ((artifactory-password))

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -1,0 +1,245 @@
+anchors:
+  artifactory-repo-put-params: &artifactory-repo-put-params
+    signing_key: ((signing-key))
+    signing_passphrase: ((signing-passphrase))
+    repo: libs-snapshot-local
+    folder: distribution-repository
+    build_uri: "https://ci.spring.io/teams/${BUILD_TEAM_NAME}/pipelines/${BUILD_PIPELINE_NAME}/jobs/${BUILD_JOB_NAME}/builds/${BUILD_NAME}"
+    build_number: "${BUILD_PIPELINE_NAME}-${BUILD_JOB_NAME}-${BUILD_NAME}"
+    disable_checksum_uploads: true
+  artifactory-task-params: &artifactory-task-params
+    ARTIFACTORY_SERVER: ((artifactory-server))
+    ARTIFACTORY_USERNAME: ((artifactory-username))
+    ARTIFACTORY_PASSWORD: ((artifactory-password))
+  build-project-task-params: &build-project-task-params
+    privileged: true
+    timeout: ((task-timeout))
+    file: git-repo/ci/tasks/build-project.yml
+  git-repo-resource-source: &git-repo-resource-source
+    uri: ((github-repo))
+    username: ((github-username))
+    password: ((github-ci-release-token))
+    branch: ((branch))
+  registry-image-resource-source: &registry-image-resource-source
+    username: ((docker-hub-username))
+    password: ((docker-hub-password))
+    tag: ((milestone))
+  sontatype-task-params: &sonatype-task-params
+    SONATYPE_USERNAME: ((sonatype-username))
+    SONATYPE_PASSWORD: ((sonatype-password))
+    SONATYPE_URL: ((sonatype-url))
+    SONATYPE_STAGING_PROFILE_ID: ((sonatype-staging-profile-id))
+  registry-mirror-vars: &registry-mirror-vars
+    registry-mirror-host: ((registry-mirror-host))
+    registry-mirror-username: ((registry-mirror-username))
+    registry-mirror-password: ((registry-mirror-password))
+resource_types:
+- name: artifactory-resource
+  type: registry-image
+  source:
+    repository: springio/artifactory-resource
+    tag: 0.0.14
+- name: pull-request
+  type: registry-image
+  source:
+    repository: teliaoss/github-pr-resource
+    tag: v0.23.0
+- name: github-release
+  type: registry-image
+  source:
+    repository: concourse/github-release-resource
+    tag: 1.5.5
+- name: github-status-resource
+  type: registry-image
+  source:
+    repository: dpb587/github-status-resource
+    tag: master
+resources:
+- name: git-repo
+  type: git
+  icon: github
+  source:
+    <<: *git-repo-resource-source
+- name: git-pull-request
+  type: pull-request
+  icon: source-pull
+  source:
+    access_token: ((github-ci-pull-request-token))
+    repository: ((github-repo-name))
+    base_branch: ((branch))
+    ignore_paths: ["ci/*"]
+- name: github-release
+  type: github-release
+  icon: briefcase-download
+  source:
+    owner: spring-projects
+    repository: spring-retry
+    access_token: ((github-ci-release-token))
+    pre_release: false
+- name: ci-images-git-repo
+  type: git
+  icon: github
+  source:
+    uri: ((github-repo))
+    branch: ((branch))
+    paths: ["ci/images/*"]
+- name: ci-image
+  type: registry-image
+  icon: docker
+  source:
+    <<: *registry-image-resource-source
+    repository: ((docker-hub-organization))/spring-retry-ci
+- name: artifactory-repo
+  type: artifactory-resource
+  icon: package-variant
+  source:
+    uri: ((artifactory-server))
+    username: ((artifactory-username))
+    password: ((artifactory-password))
+    build_name: ((build-name))
+- name: repo-status-build
+  type: github-status-resource
+  icon: eye-check-outline
+  source:
+    repository: ((github-repo-name))
+    access_token: ((github-ci-status-token))
+    branch: ((branch))
+    context: build
+jobs:
+- name: build-ci-image
+  plan:
+  - get: ci-images-git-repo
+    trigger: true
+  - get: git-repo
+  - in_parallel:
+    - task: build-ci-image
+      privileged: true
+      file: git-repo/ci/tasks/build-ci-image.yml
+      output_mapping:
+        image: ci-image
+      vars:
+        ci-image-name: ci-image
+        <<: *registry-mirror-vars
+  - in_parallel:
+    - put: ci-image
+      params:
+        image: ci-image/image.tar
+- name: build
+  serial: true
+  public: true
+  plan:
+  - get: ci-image
+  - get: git-repo
+    trigger: true
+  - put: repo-status-build
+    params: { state: "pending", commit: "git-repo" }
+  - do:
+    - task: build-project
+      image: ci-image
+      <<: *build-project-task-params
+    on_failure:
+      do:
+      - put: repo-status-build
+        params: { state: "failure", commit: "git-repo" }
+  - put: repo-status-build
+    params: { state: "success", commit: "git-repo" }
+  - put: artifactory-repo
+    params:
+      <<: *artifactory-repo-put-params
+- name: build-pull-requests
+  serial: true
+  public: true
+  plan:
+  - get: ci-image
+  - get: git-repo
+    resource: git-pull-request
+    trigger: true
+    version: every
+  - do:
+    - put: git-pull-request
+      params:
+        path: git-repo
+        status: pending
+    - task: build-project
+      image: ci-image
+      file: git-repo/ci/tasks/build-pr-project.yml
+    on_success:
+      put: git-pull-request
+      params:
+        path: git-repo
+        status: success
+    on_failure:
+      put: git-pull-request
+      params:
+        path: git-repo
+        status: failure
+- name: stage-release
+  serial: true
+  plan:
+  - get: ci-image
+  - get: git-repo
+    trigger: false
+  - task: stage
+    image: ci-image
+    file: git-repo/ci/tasks/stage.yml
+    params:
+      RELEASE_TYPE: RELEASE
+  - put: artifactory-repo
+    params:
+      <<: *artifactory-repo-put-params
+      repo: libs-staging-local
+  - put: git-repo
+    params:
+      repository: stage-git-repo
+- name: promote-release
+  serial: true
+  plan:
+  - get: ci-image
+  - get: git-repo
+    trigger: false
+  - get: artifactory-repo
+    trigger: false
+    passed: [stage-release]
+    params:
+      download_artifacts: true
+      save_build_info: true
+  - task: promote
+    image: ci-image
+    file: git-repo/ci/tasks/promote.yml
+    params:
+      RELEASE_TYPE: RELEASE
+      <<: *artifactory-task-params
+      <<: *sonatype-task-params
+- name: create-github-release
+  serial: true
+  plan:
+  - get: ci-image
+  - get: git-repo
+  - get: artifactory-repo
+    trigger: true
+    passed: [promote-release]
+    params:
+      download_artifacts: false
+      save_build_info: true
+  - task: generate-changelog
+    file: git-repo/ci/tasks/generate-changelog.yml
+    params:
+      RELEASE_TYPE: RELEASE
+      GITHUB_USERNAME: ((github-username))
+      GITHUB_TOKEN: ((github-ci-release-token))
+    vars:
+      <<: *registry-mirror-vars
+  - put: github-release
+    params:
+      name: generated-changelog/tag
+      tag: generated-changelog/tag
+      body: generated-changelog/changelog.md
+groups:
+- name: "build"
+  jobs: ["build"]
+- name: "releases"
+  jobs: ["stage-release", "promote-release", "create-github-release"]
+- name: "ci-images"
+  jobs: ["build-ci-image"]
+- name: "pull-requests"
+  jobs: ["build-pull-requests"]

--- a/ci/scripts/build-project.sh
+++ b/ci/scripts/build-project.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/common.sh
+repository=$(pwd)/distribution-repository
+if [ -z "$(ls -A maven)" ]; then
+   echo "Maven cache not available."
+else
+   echo "Maven cache found."
+fi
+pushd git-repo > /dev/null
+./mvnw clean deploy -U -Pfull -DaltDeploymentRepository=distribution::default::file://${repository}
+popd > /dev/null

--- a/ci/scripts/common.sh
+++ b/ci/scripts/common.sh
@@ -1,0 +1,4 @@
+source /opt/concourse-java.sh
+
+setup_symlinks
+cleanup_maven_repo "org.springframework.retry"

--- a/ci/scripts/generate-changelog.sh
+++ b/ci/scripts/generate-changelog.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+set -e
+
+CONFIG_DIR=git-repo/ci/config
+version=$( cat artifactory-repo/build-info.json | jq -r '.buildInfo.modules[0].id' | sed 's/.*:.*:\(.*\)/\1/' )
+
+java -jar /github-changelog-generator.jar \
+  --spring.config.location=${CONFIG_DIR}/changelog-generator.yml \
+  ${version} generated-changelog/changelog.md
+
+echo ${version} > generated-changelog/version
+echo v${version} > generated-changelog/tag

--- a/ci/scripts/promote.sh
+++ b/ci/scripts/promote.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+source $(dirname $0)/common.sh
+CONFIG_DIR=git-repo/ci/config
+
+version=$( cat artifactory-repo/build-info.json | jq -r '.buildInfo.modules[0].id' | sed 's/.*:.*:\(.*\)/\1/' )
+export BUILD_INFO_LOCATION=$(pwd)/artifactory-repo/build-info.json
+
+java -jar /opt/concourse-release-scripts.jar \
+  --spring.config.location=${CONFIG_DIR}/release-scripts.yml \
+  publishToCentral $RELEASE_TYPE $BUILD_INFO_LOCATION artifactory-repo || { exit 1; }
+
+java -jar /opt/concourse-release-scripts.jar \
+  --spring.config.location=${CONFIG_DIR}/release-scripts.yml \
+  promote $RELEASE_TYPE $BUILD_INFO_LOCATION || { exit 1; }
+
+echo "Promotion complete"
+echo $version > version/version

--- a/ci/scripts/stage.sh
+++ b/ci/scripts/stage.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -e
+
+source $(dirname $0)/common.sh
+repository=$(pwd)/distribution-repository
+
+pushd git-repo > /dev/null
+git fetch --tags --all > /dev/null
+popd > /dev/null
+
+git clone git-repo stage-git-repo > /dev/null
+
+pushd stage-git-repo > /dev/null
+
+snapshotVersion=$( get_revision_from_pom )
+stageVersion=$( get_next_release $snapshotVersion)
+nextVersion=$( bump_version_number $snapshotVersion)
+echo "Staging $stageVersion (next version will be $nextVersion)"
+
+set_revision_to_pom "$stageVersion"
+git config user.name "Spring Builds" > /dev/null
+git config user.email "spring-builds@users.noreply.github.com" > /dev/null
+git add pom.xml > /dev/null
+git commit -m"Release v$stageVersion" > /dev/null
+git tag -a "v$stageVersion" -m"Release v$stageVersion" > /dev/null
+
+./mvnw clean deploy -U -Pfull -DaltDeploymentRepository=distribution::default::file://${repository}
+
+git reset --hard HEAD^ > /dev/null
+if [[ $nextVersion != $snapshotVersion ]]; then
+	echo "Setting next development version (v$nextVersion)"
+	set_revision_to_pom "$nextVersion"
+	git add pom.xml > /dev/null
+	git commit -m"Next development version (v$nextVersion)" > /dev/null
+fi;
+
+echo "DONE"
+
+popd > /dev/null

--- a/ci/tasks/build-ci-image.yml
+++ b/ci/tasks/build-ci-image.yml
@@ -1,0 +1,31 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: concourse/oci-build-task
+    tag: 0.9.1
+    registry_mirror:
+      host: ((registry-mirror-host))
+      username: ((registry-mirror-username))
+      password: ((registry-mirror-password))
+inputs:
+- name: ci-images-git-repo
+outputs:
+- name: image
+caches:
+- path: ci-image-cache
+params:
+  CONTEXT: ci-images-git-repo/ci/images
+  DOCKERFILE: ci-images-git-repo/ci/images/((ci-image-name))/Dockerfile
+  DOCKER_HUB_AUTH: ((docker-hub-auth))
+run:
+  path: /bin/sh
+  args:
+  - "-c"
+  - |
+    mkdir -p /root/.docker
+    cat > /root/.docker/config.json <<EOF
+    { "auths": { "https://index.docker.io/v1/": { "auth": "$DOCKER_HUB_AUTH" }}}
+    EOF
+    build

--- a/ci/tasks/build-pr-project.yml
+++ b/ci/tasks/build-pr-project.yml
@@ -1,0 +1,10 @@
+---
+platform: linux
+inputs:
+- name: git-repo
+outputs:
+- name: distribution-repository
+caches:
+- path: maven
+run:
+  path: git-repo/ci/scripts/build-project.sh

--- a/ci/tasks/build-project.yml
+++ b/ci/tasks/build-project.yml
@@ -1,0 +1,10 @@
+---
+platform: linux
+inputs:
+- name: git-repo
+outputs:
+- name: distribution-repository
+caches:
+- path: maven
+run:
+  path: git-repo/ci/scripts/build-project.sh

--- a/ci/tasks/generate-changelog.yml
+++ b/ci/tasks/generate-changelog.yml
@@ -1,0 +1,24 @@
+---
+platform: linux
+image_resource:
+  type: registry-image
+  source:
+    repository: springio/github-changelog-generator
+    tag: '0.0.7'
+    registry_mirror:
+      host: ((registry-mirror-host))
+      username: ((registry-mirror-username))
+      password: ((registry-mirror-password))
+inputs:
+  - name: git-repo
+  - name: artifactory-repo
+outputs:
+  - name: generated-changelog
+params:
+  GITHUB_ORGANIZATION:
+  GITHUB_REPO:
+  GITHUB_USERNAME:
+  GITHUB_TOKEN:
+  RELEASE_TYPE:
+run:
+  path: git-repo/ci/scripts/generate-changelog.sh

--- a/ci/tasks/promote.yml
+++ b/ci/tasks/promote.yml
@@ -1,0 +1,17 @@
+---
+platform: linux
+inputs:
+- name: git-repo
+- name: artifactory-repo
+outputs:
+- name: version
+params:
+  ARTIFACTORY_SERVER:
+  ARTIFACTORY_USERNAME:
+  ARTIFACTORY_PASSWORD:
+  SONATYPE_USERNAME:
+  SONATYPE_PASSWORD:
+  SONATYPE_URL:
+  SONATYPE_STAGING_PROFILE_ID:
+run:
+  path: git-repo/ci/scripts/promote.sh

--- a/ci/tasks/stage.yml
+++ b/ci/tasks/stage.yml
@@ -1,0 +1,11 @@
+---
+platform: linux
+inputs:
+- name: git-repo
+outputs:
+- name: stage-git-repo
+- name: distribution-repository
+caches:
+- path: maven
+run:
+  path: git-repo/ci/scripts/stage.sh


### PR DESCRIPTION
This commit provides an integration with Concourse. A sample pipeline has been deployed to https://ci.spring.io/teams/spring-retry/pipelines/spring-retry-1.3.x (private for now).

The pipeline runs the build for every commit and publishes a new snapshot on `repo.spring.io/snapshot`. There is also a standard release pipeline to release the bits to Maven Central and generate a changelog automatically based on the current labels. If we decide to harmonize the labels, we'd need to change the configuration.