### PR TITLE
GH-276: Expose BackOffPolicy building logic

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -413,8 +413,8 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 				}
 			}
 		}
-		return BackOffPolicyBuilder.newBuilder().delay(min).maxDelay(max).multiplier(multiplier).isRandom(isRandom)
-				.withSleeper(this.sleeper).build();
+		return BackOffPolicyBuilder.newBuilder().delay(min).maxDelay(max).multiplier(multiplier).random(isRandom)
+				.sleeper(this.sleeper).build();
 	}
 
 	/**

--- a/src/main/java/org/springframework/retry/backoff/BackOffPolicyBuilder.java
+++ b/src/main/java/org/springframework/retry/backoff/BackOffPolicyBuilder.java
@@ -25,6 +25,10 @@ package org.springframework.retry.backoff;
  * <p>
  * Examples: <pre>
  *
+ * // Default {@link FixedBackOffPolicy} with 1000ms delay
+ * BackOffPolicyBuilder
+ * 		.newDefaultPolicy();
+ *
  * // {@link FixedBackOffPolicy}
  * BackOffPolicyBuilder
  * 		.newBuilder()
@@ -52,8 +56,8 @@ package org.springframework.retry.backoff;
  * 		.delay(3000)
  * 		.maxDelay(5000)
  * 		.multiplier(1.5)
- * 		.isRandom(true)
- * 		.withSleeper(mySleeper)
+ * 		.random(true)
+ * 		.sleeper(mySleeper)
  * 		.build();
  * </pre>
  * <p>
@@ -74,7 +78,7 @@ public class BackOffPolicyBuilder {
 
 	private double multiplier;
 
-	private boolean isRandom;
+	private boolean random;
 
 	private Sleeper sleeper;
 
@@ -87,6 +91,14 @@ public class BackOffPolicyBuilder {
 	 */
 	public static BackOffPolicyBuilder newBuilder() {
 		return new BackOffPolicyBuilder();
+	}
+
+	/**
+	 * Creates a new {@link FixedBackOffPolicy} instance with a delay of 1000ms.
+	 * @return the back off policy instance
+	 */
+	public static BackOffPolicy newDefaultPolicy() {
+		return new BackOffPolicyBuilder().build();
 	}
 
 	/**
@@ -125,11 +137,11 @@ public class BackOffPolicyBuilder {
 	 * In the exponential case ({@link #multiplier} &gt; 0) set this to true to have the
 	 * backoff delays randomized, so that the maximum delay is multiplier times the
 	 * previous delay and the distribution is uniform between the two values.
-	 * @param isRandom the flag to signal randomization is required
+	 * @param random the flag to signal randomization is required
 	 * @return this
 	 */
-	public BackOffPolicyBuilder isRandom(boolean isRandom) {
-		this.isRandom = isRandom;
+	public BackOffPolicyBuilder random(boolean random) {
+		this.random = random;
 		return this;
 	}
 
@@ -139,7 +151,7 @@ public class BackOffPolicyBuilder {
 	 * @param sleeper the {@link Sleeper} instance
 	 * @return this
 	 */
-	public BackOffPolicyBuilder withSleeper(Sleeper sleeper) {
+	public BackOffPolicyBuilder sleeper(Sleeper sleeper) {
 		this.sleeper = sleeper;
 		return this;
 	}
@@ -151,7 +163,7 @@ public class BackOffPolicyBuilder {
 	public BackOffPolicy build() {
 		if (this.multiplier > 0) {
 			ExponentialBackOffPolicy policy = new ExponentialBackOffPolicy();
-			if (this.isRandom) {
+			if (this.random) {
 				policy = new ExponentialRandomBackOffPolicy();
 			}
 			policy.setInitialInterval(this.delay);

--- a/src/main/java/org/springframework/retry/backoff/BackOffPolicyBuilder.java
+++ b/src/main/java/org/springframework/retry/backoff/BackOffPolicyBuilder.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.backoff;
+
+/**
+ * Fluent API for creating a {@link BackOffPolicy} based on given attributes. The delay
+ * values are expressed in milliseconds. If any provided value is less than one, the
+ * resulting policy will set it to one. The default policy is a {@link FixedBackOffPolicy}
+ * with a delay of 1000ms.
+ *
+ * <p>
+ * Examples: <pre>
+ *
+ * // {@link FixedBackOffPolicy}
+ * BackOffPolicyBuilder
+ * 		.newBuilder()
+ * 		.delay(2000)
+ * 		.build();
+ *
+ * // {@link UniformRandomBackOffPolicy}
+ * BackOffPolicyBuilder
+ * 		.newBuilder()
+ * 		.delay(500)
+ * 		.maxDelay(1000)
+ * 		.build();
+ *
+ * // {@link ExponentialBackOffPolicy}
+ * BackOffPolicyBuilder
+ * 		.newBuilder()
+ * 		.delay(1000)
+ * 		.maxDelay(5000)
+ * 		.multiplier(2)
+ * 		.build();
+ *
+ * // {@link ExponentialRandomBackOffPolicy} with provided {@link Sleeper}
+ * BackOffPolicyBuilder
+ * 		.newBuilder()
+ * 		.delay(3000)
+ * 		.maxDelay(5000)
+ * 		.multiplier(1.5)
+ * 		.isRandom(true)
+ * 		.withSleeper(mySleeper)
+ * 		.build();
+ * </pre>
+ * <p>
+ * Not thread safe. Building should be performed in a single thread. The resulting
+ * {@link BackOffPolicy} however is expected to be thread-safe and designed for moderate
+ * load concurrent access.
+ *
+ * @author Tomaz Fernandes
+ * @since 1.3.3
+ */
+public class BackOffPolicyBuilder {
+
+	private static final long DEFAULT_INITIAL_DELAY = 1000L;
+
+	private long delay = DEFAULT_INITIAL_DELAY;
+
+	private long maxDelay;
+
+	private double multiplier;
+
+	private boolean isRandom;
+
+	private Sleeper sleeper;
+
+	private BackOffPolicyBuilder() {
+	}
+
+	/**
+	 * Creates a new {@link BackOffPolicyBuilder} instance.
+	 * @return the builder instance
+	 */
+	public static BackOffPolicyBuilder newBuilder() {
+		return new BackOffPolicyBuilder();
+	}
+
+	/**
+	 * A canonical backoff period. Used as an initial value in the exponential case, and
+	 * as a minimum value in the uniform case.
+	 * @param delay the initial or canonical backoff period in milliseconds
+	 * @return this
+	 */
+	public BackOffPolicyBuilder delay(long delay) {
+		this.delay = delay;
+		return this;
+	}
+
+	/**
+	 * The maximum wait in milliseconds between retries. If less than {@link #delay(long)}
+	 * then a default value is applied depending on the resulting policy.
+	 * @param maxDelay the maximum wait between retries in milliseconds
+	 * @return this
+	 */
+	public BackOffPolicyBuilder maxDelay(long maxDelay) {
+		this.maxDelay = maxDelay;
+		return this;
+	}
+
+	/**
+	 * If positive, then used as a multiplier for generating the next delay for backoff.
+	 * @param multiplier a multiplier to use to calculate the next backoff delay
+	 * @return this
+	 */
+	public BackOffPolicyBuilder multiplier(double multiplier) {
+		this.multiplier = multiplier;
+		return this;
+	}
+
+	/**
+	 * In the exponential case ({@link #multiplier} &gt; 0) set this to true to have the
+	 * backoff delays randomized, so that the maximum delay is multiplier times the
+	 * previous delay and the distribution is uniform between the two values.
+	 * @param isRandom the flag to signal randomization is required
+	 * @return this
+	 */
+	public BackOffPolicyBuilder isRandom(boolean isRandom) {
+		this.isRandom = isRandom;
+		return this;
+	}
+
+	/**
+	 * The {@link Sleeper} instance to be used to back off. Policies default to
+	 * {@link ThreadWaitSleeper}.
+	 * @param sleeper the {@link Sleeper} instance
+	 * @return this
+	 */
+	public BackOffPolicyBuilder withSleeper(Sleeper sleeper) {
+		this.sleeper = sleeper;
+		return this;
+	}
+
+	/**
+	 * Builds the {@link BackOffPolicy} with the given parameters.
+	 * @return the {@link BackOffPolicy} instance
+	 */
+	public BackOffPolicy build() {
+		if (this.multiplier > 0) {
+			ExponentialBackOffPolicy policy = new ExponentialBackOffPolicy();
+			if (this.isRandom) {
+				policy = new ExponentialRandomBackOffPolicy();
+			}
+			policy.setInitialInterval(this.delay);
+			policy.setMultiplier(this.multiplier);
+			policy.setMaxInterval(
+					this.maxDelay > this.delay ? this.maxDelay : ExponentialBackOffPolicy.DEFAULT_MAX_INTERVAL);
+			if (this.sleeper != null) {
+				policy.setSleeper(this.sleeper);
+			}
+			return policy;
+		}
+		if (this.maxDelay > this.delay) {
+			UniformRandomBackOffPolicy policy = new UniformRandomBackOffPolicy();
+			policy.setMinBackOffPeriod(this.delay);
+			policy.setMaxBackOffPeriod(this.maxDelay);
+			if (this.sleeper != null) {
+				policy.setSleeper(this.sleeper);
+			}
+			return policy;
+		}
+		FixedBackOffPolicy policy = new FixedBackOffPolicy();
+		policy.setBackOffPeriod(this.delay);
+		if (this.sleeper != null) {
+			policy.setSleeper(this.sleeper);
+		}
+		return policy;
+	}
+
+}

--- a/src/test/java/org/springframework/retry/backoff/BackOffPolicyBuilderTests.java
+++ b/src/test/java/org/springframework/retry/backoff/BackOffPolicyBuilderTests.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2022-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.backoff;
+
+import org.junit.Test;
+
+import org.springframework.beans.DirectFieldAccessor;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+/**
+ * @author Tomaz Fernandes
+ * @since 1.3.3
+ */
+public class BackOffPolicyBuilderTests {
+
+	@Test
+	public void shouldCreateDefaultBackOffPolicy() {
+		Sleeper mockSleeper = mock(Sleeper.class);
+		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().withSleeper(mockSleeper).build();
+		assertTrue(FixedBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
+		FixedBackOffPolicy policy = (FixedBackOffPolicy) backOffPolicy;
+		assertEquals(1000, policy.getBackOffPeriod());
+		assertEquals(mockSleeper, new DirectFieldAccessor(policy).getPropertyValue("sleeper"));
+	}
+
+	@Test
+	public void shouldCreateFixedBackOffPolicy() {
+		Sleeper mockSleeper = mock(Sleeper.class);
+		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(3500).withSleeper(mockSleeper).build();
+		assertTrue(FixedBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
+		FixedBackOffPolicy policy = (FixedBackOffPolicy) backOffPolicy;
+		assertEquals(3500, policy.getBackOffPeriod());
+		assertEquals(mockSleeper, new DirectFieldAccessor(policy).getPropertyValue("sleeper"));
+	}
+
+	@Test
+	public void shouldCreateUniformRandomBackOffPolicy() {
+		Sleeper mockSleeper = mock(Sleeper.class);
+		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(1).maxDelay(5000).withSleeper(mockSleeper)
+				.build();
+		assertTrue(UniformRandomBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
+		UniformRandomBackOffPolicy policy = (UniformRandomBackOffPolicy) backOffPolicy;
+		assertEquals(1, policy.getMinBackOffPeriod());
+		assertEquals(5000, policy.getMaxBackOffPeriod());
+		assertEquals(mockSleeper, new DirectFieldAccessor(policy).getPropertyValue("sleeper"));
+	}
+
+	@Test
+	public void shouldCreateExponentialBackOff() {
+		Sleeper mockSleeper = mock(Sleeper.class);
+		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(100).maxDelay(1000).multiplier(2)
+				.isRandom(false).withSleeper(mockSleeper).build();
+		assertTrue(ExponentialBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
+		ExponentialBackOffPolicy policy = (ExponentialBackOffPolicy) backOffPolicy;
+		assertEquals(100, policy.getInitialInterval());
+		assertEquals(1000, policy.getMaxInterval());
+		assertEquals(2, policy.getMultiplier(), 0);
+		assertEquals(mockSleeper, new DirectFieldAccessor(policy).getPropertyValue("sleeper"));
+	}
+
+	@Test
+	public void shouldCreateExponentialRandomBackOff() {
+		Sleeper mockSleeper = mock(Sleeper.class);
+		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(10000).maxDelay(100000).multiplier(10)
+				.isRandom(true).withSleeper(mockSleeper).build();
+		assertTrue(ExponentialRandomBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
+		ExponentialRandomBackOffPolicy policy = (ExponentialRandomBackOffPolicy) backOffPolicy;
+		assertEquals(10000, policy.getInitialInterval());
+		assertEquals(100000, policy.getMaxInterval());
+		assertEquals(10, policy.getMultiplier(), 0);
+		assertEquals(mockSleeper, new DirectFieldAccessor(policy).getPropertyValue("sleeper"));
+	}
+
+}

--- a/src/test/java/org/springframework/retry/backoff/BackOffPolicyBuilderTests.java
+++ b/src/test/java/org/springframework/retry/backoff/BackOffPolicyBuilderTests.java
@@ -32,8 +32,16 @@ public class BackOffPolicyBuilderTests {
 
 	@Test
 	public void shouldCreateDefaultBackOffPolicy() {
+		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newDefaultPolicy();
+		assertTrue(FixedBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
+		FixedBackOffPolicy policy = (FixedBackOffPolicy) backOffPolicy;
+		assertEquals(1000, policy.getBackOffPeriod());
+	}
+
+	@Test
+	public void shouldCreateDefaultBackOffPolicyViaNewBuilder() {
 		Sleeper mockSleeper = mock(Sleeper.class);
-		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().withSleeper(mockSleeper).build();
+		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().sleeper(mockSleeper).build();
 		assertTrue(FixedBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
 		FixedBackOffPolicy policy = (FixedBackOffPolicy) backOffPolicy;
 		assertEquals(1000, policy.getBackOffPeriod());
@@ -43,7 +51,7 @@ public class BackOffPolicyBuilderTests {
 	@Test
 	public void shouldCreateFixedBackOffPolicy() {
 		Sleeper mockSleeper = mock(Sleeper.class);
-		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(3500).withSleeper(mockSleeper).build();
+		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(3500).sleeper(mockSleeper).build();
 		assertTrue(FixedBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
 		FixedBackOffPolicy policy = (FixedBackOffPolicy) backOffPolicy;
 		assertEquals(3500, policy.getBackOffPeriod());
@@ -53,7 +61,7 @@ public class BackOffPolicyBuilderTests {
 	@Test
 	public void shouldCreateUniformRandomBackOffPolicy() {
 		Sleeper mockSleeper = mock(Sleeper.class);
-		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(1).maxDelay(5000).withSleeper(mockSleeper)
+		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(1).maxDelay(5000).sleeper(mockSleeper)
 				.build();
 		assertTrue(UniformRandomBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
 		UniformRandomBackOffPolicy policy = (UniformRandomBackOffPolicy) backOffPolicy;
@@ -66,7 +74,7 @@ public class BackOffPolicyBuilderTests {
 	public void shouldCreateExponentialBackOff() {
 		Sleeper mockSleeper = mock(Sleeper.class);
 		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(100).maxDelay(1000).multiplier(2)
-				.isRandom(false).withSleeper(mockSleeper).build();
+				.random(false).sleeper(mockSleeper).build();
 		assertTrue(ExponentialBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
 		ExponentialBackOffPolicy policy = (ExponentialBackOffPolicy) backOffPolicy;
 		assertEquals(100, policy.getInitialInterval());
@@ -79,7 +87,7 @@ public class BackOffPolicyBuilderTests {
 	public void shouldCreateExponentialRandomBackOff() {
 		Sleeper mockSleeper = mock(Sleeper.class);
 		BackOffPolicy backOffPolicy = BackOffPolicyBuilder.newBuilder().delay(10000).maxDelay(100000).multiplier(10)
-				.isRandom(true).withSleeper(mockSleeper).build();
+				.random(true).sleeper(mockSleeper).build();
 		assertTrue(ExponentialRandomBackOffPolicy.class.isAssignableFrom(backOffPolicy.getClass()));
 		ExponentialRandomBackOffPolicy policy = (ExponentialRandomBackOffPolicy) backOffPolicy;
 		assertEquals(10000, policy.getInitialInterval());


### PR DESCRIPTION
`BackOffPolicyBuilder` implementation to expose `BackOffPolicy` building logic to other projects.

A few quick considerations.

My main goals here were consistency with the rest of the project, and reduced risk of breaking behaviors.

That impacted a few decisions, such as:

* I didn't change anything in the actual algorithm to reduce risk of accidentally changing any behavior
* I used `primitives` instead of their classes counterparts (`Long`, `Double`, `Boolean`)
Using classes we'd be able to set a value only if not `null`, delegating to the policy which default value to use. But we'd have to introduce null checks all around, which might interfere the first bullet above. Also, this helps keeping consistency with the rest of the project.
* No validation if the inputs are `> 0`. If these validations were introduced, they would change the behavior for users that may be relying on passing values such as `-1` to the annotation to let the policy set a default value.
* I copied and pasted a lot of the javadocs, besides the main algorithm. I don't know if there's a way to give proper credit in this case.

If you have any suggestions regarding the API, implementation, or anything else, please let me know, and also if there's anything that needs to be changed.

Thanks