### PR TITLE
Rethrow particular not-retryable exceptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,9 +200,8 @@ Foo foo = template.execute(new RetryCallback<Foo>() {
 If the business logic does not succeed before the template decides to abort, the client is
 given the chance to do some alternate processing through the recovery callback.
 
-Version 1.3.3 added the `noRecoveryForNotRetryable` and `noRecoveryForNotRetryableExceptions` properties to the template.
-When `noRecoveryForNotRetryable` is `true`, the recovery callback is not invoked if the retry policy is configured with a not-retryable exception and one is thrown.
-The same behavior for exceptions set by `noRecoveryForNotRetryableExceptions`.
+Version 1.3.3 added the `noRecoveryForNotRetryable` property to the template.
+When `true`, the recovery callback is not invoked if the retry policy is configured with a not-retryable exception and one is thrown.
 By default, the recovery callback is always called, regardless of whether the exception is retryable or not.
 
 ## Stateless Retry

--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ Foo foo = template.execute(new RetryCallback<Foo>() {
 If the business logic does not succeed before the template decides to abort, the client is
 given the chance to do some alternate processing through the recovery callback.
 
-Version 1.3.3 added the `noRecoveryForNotRetryable` property to the template.
-When `true`, the recovery callback is not invoked if the retry policy is configured with a not-retryable exception and one is thrown.
+Version 1.3.3 added the `noRecoveryForNotRetryable` and `noRecoveryForNotRetryableExceptions` properties to the template.
+When `noRecoveryForNotRetryable` is `true`, the recovery callback is not invoked if the retry policy is configured with a not-retryable exception and one is thrown.
+The same behavior for exceptions set by `noRecoveryForNotRetryableExceptions`.
 By default, the recovery callback is always called, regardless of whether the exception is retryable or not.
 
 ## Stateless Retry
@@ -580,7 +581,7 @@ Expressions can contain property placeholders, such as `#{${max.delay}}` or
 during initialization. There is no root object for the evaluation but they can reference
 other beans in the context.
 
-Version 1.3.3 added the `rethrow` attribute to `@Retryable`; when `true` any exceptions that are not retryable are thrown unchanged to the caller and the `@Recover` method is not called.
+Version 1.3.3 added the `rethrow` and `rethrowExceptions` attributes to `@Retryable`; when `rethrow` is `true` any exceptions that are not retryable are thrown unchanged to the caller and the `@Recover` method is not called. The same behavior for exceptions listed in `rethrowExceptions`.
 
 #### <a name="Additional_Dependencies"></a> Additional Dependencies
 

--- a/README.md
+++ b/README.md
@@ -200,8 +200,9 @@ Foo foo = template.execute(new RetryCallback<Foo>() {
 If the business logic does not succeed before the template decides to abort, the client is
 given the chance to do some alternate processing through the recovery callback.
 
-Version 1.3.3 added the `noRecoveryForNotRetryable` property to the template.
-When `true`, the recovery callback is not invoked if the retry policy is configured with a not-retryable exception and one is thrown.
+Version 1.3.3 added the `noRecoveryForNotRetryable` and `noRecoveryForNotRetryableExceptions` properties to the template.
+When `noRecoveryForNotRetryable` is `true`, the recovery callback is not invoked if the retry policy is configured with a not-retryable exception and one is thrown.
+The same behavior for exceptions set by `noRecoveryForNotRetryableExceptions`.
 By default, the recovery callback is always called, regardless of whether the exception is retryable or not.
 
 ## Stateless Retry

--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -218,6 +218,7 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 		template.setRetryPolicy(getRetryPolicy(retryable));
 		template.setBackOffPolicy(getBackoffPolicy(retryable.backoff()));
 		template.setNoRecoveryForNotRetryable(retryable.rethrow());
+		template.setNoRecoveryForNotRetryableExceptions(retryable.rethrowExceptions());
 		return RetryInterceptorBuilder.stateless().retryOperations(template).label(retryable.label())
 				.recoverer(getRecoverer(target, method, retryable.rethrow())).build();
 	}
@@ -227,6 +228,7 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 		RetryTemplate template = createTemplate(retryable.listeners());
 		template.setRetryContextCache(this.retryContextCache);
 		template.setNoRecoveryForNotRetryable(rethrow);
+		template.setNoRecoveryForNotRetryableExceptions(retryable.rethrowExceptions());
 
 		CircuitBreaker circuit = AnnotatedElementUtils.findMergedAnnotation(method, CircuitBreaker.class);
 		if (circuit == null) {

--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -217,8 +217,7 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 		RetryTemplate template = createTemplate(retryable.listeners());
 		template.setRetryPolicy(getRetryPolicy(retryable));
 		template.setBackOffPolicy(getBackoffPolicy(retryable.backoff()));
-		template.setNoRecoveryForNotRetryable(retryable.rethrow());
-		template.setNoRecoveryForNotRetryableExceptions(retryable.rethrowExceptions());
+		template.setNoRecoveryForNotRetryable(retryable.rethrow() || retryable.rethrowExceptions().length > 0);
 		return RetryInterceptorBuilder.stateless().retryOperations(template).label(retryable.label())
 				.recoverer(getRecoverer(target, method, retryable.rethrow())).build();
 	}
@@ -227,8 +226,7 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 		boolean rethrow = retryable.rethrow();
 		RetryTemplate template = createTemplate(retryable.listeners());
 		template.setRetryContextCache(this.retryContextCache);
-		template.setNoRecoveryForNotRetryable(rethrow);
-		template.setNoRecoveryForNotRetryableExceptions(retryable.rethrowExceptions());
+		template.setNoRecoveryForNotRetryable(rethrow || retryable.rethrowExceptions().length > 0);
 
 		CircuitBreaker circuit = AnnotatedElementUtils.findMergedAnnotation(method, CircuitBreaker.class);
 		if (circuit == null) {
@@ -345,7 +343,11 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 						Integer.class);
 			}
 		}
-		if (includes.length == 0 && excludes.length == 0) {
+		Class<? extends Throwable>[] rethrowExceptions = (Class<? extends Throwable>[]) attrs.get("rethrowExceptions");
+		if (rethrowExceptions == null) {
+			rethrowExceptions = new Class[0];
+		}
+		if (includes.length == 0 && excludes.length == 0 && rethrowExceptions.length == 0) {
 			SimpleRetryPolicy simple = hasExpression
 					? new ExpressionRetryPolicy(resolve(exceptionExpression)).withBeanFactory(this.beanFactory)
 					: new SimpleRetryPolicy();
@@ -357,6 +359,9 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 			policyMap.put(type, true);
 		}
 		for (Class<? extends Throwable> type : excludes) {
+			policyMap.put(type, false);
+		}
+		for (Class<? extends Throwable> type : rethrowExceptions) {
 			policyMap.put(type, false);
 		}
 		boolean retryNotExcluded = includes.length == 0;

--- a/src/main/java/org/springframework/retry/annotation/Retryable.java
+++ b/src/main/java/org/springframework/retry/annotation/Retryable.java
@@ -138,4 +138,12 @@ public @interface Retryable {
 	 */
 	boolean rethrow() default false;
 
+	/**
+	 * For these exception types raw exceptions are thrown without being wrapped and no
+	 * recovery is performed not-retryable exceptions.
+	 * @return exception types not to recover
+	 * @since 1.3.3
+	 */
+	Class<? extends Throwable>[] rethrowExceptions() default {};
+
 }

--- a/src/main/java/org/springframework/retry/support/RetryTemplate.java
+++ b/src/main/java/org/springframework/retry/support/RetryTemplate.java
@@ -98,6 +98,8 @@ public class RetryTemplate implements RetryOperations {
 
 	private boolean noRecoveryForNotRetryable;
 
+	private Class<? extends Throwable>[] noRecoveryForNotRetryableExceptions;
+
 	/**
 	 * Main entry point to configure RetryTemplate using fluent API. See
 	 * {@link RetryTemplateBuilder} for usage examples and details.
@@ -136,6 +138,20 @@ public class RetryTemplate implements RetryOperations {
 	 */
 	public void setNoRecoveryForNotRetryable(boolean noRecoveryForNotRetryable) {
 		this.noRecoveryForNotRetryable = noRecoveryForNotRetryable;
+	}
+
+	/**
+	 * Set exception types to not call the recovery callback (if any) when a not-retryable
+	 * exception is thrown by the target code in
+	 * {@link #execute(RetryCallback, RecoveryCallback)}. By default, the callback is
+	 * invoked when retries are exhausted, or immediately for not-retryable exceptions.
+	 * @param noRecoveryForNotRetryableExceptions the noRecoveryForNotRetryableExceptions
+	 * to set
+	 * @since 1.3.3
+	 */
+	public void setNoRecoveryForNotRetryableExceptions(
+			Class<? extends Throwable>... noRecoveryForNotRetryableExceptions) {
+		this.noRecoveryForNotRetryableExceptions = noRecoveryForNotRetryableExceptions;
 	}
 
 	/**
@@ -547,8 +563,7 @@ public class RetryTemplate implements RetryOperations {
 			this.retryContextCache.remove(state.getKey());
 		}
 		// TODO: In 2.0 add retryForException() to the interface.
-		if (this.noRecoveryForNotRetryable && retryPolicy instanceof SimpleRetryPolicy
-				&& !((SimpleRetryPolicy) retryPolicy).retryForException(context.getLastThrowable())) {
+		if (shouldRethrowWithoutRecovery(context.getLastThrowable())) {
 			throw context.getLastThrowable();
 		}
 		if (recoveryCallback != null) {
@@ -564,7 +579,8 @@ public class RetryTemplate implements RetryOperations {
 	}
 
 	protected <E extends Throwable> void rethrow(RetryContext context, String message) throws E {
-		if (this.throwLastExceptionOnExhausted || this.noRecoveryForNotRetryable) {
+		if (this.throwLastExceptionOnExhausted || this.noRecoveryForNotRetryable
+				|| isNoRecoveryException(context.getLastThrowable())) {
 			@SuppressWarnings("unchecked")
 			E rethrow = (E) context.getLastThrowable();
 			throw rethrow;
@@ -585,6 +601,17 @@ public class RetryTemplate implements RetryOperations {
 	 */
 	protected boolean shouldRethrow(RetryPolicy retryPolicy, RetryContext context, RetryState state) {
 		return state != null && state.rollbackFor(context.getLastThrowable());
+	}
+
+	private boolean shouldRethrowWithoutRecovery(Throwable throwable) {
+		return (this.noRecoveryForNotRetryable || isNoRecoveryException(throwable))
+				&& retryPolicy instanceof SimpleRetryPolicy
+				&& !((SimpleRetryPolicy) retryPolicy).retryForException(throwable);
+	}
+
+	private boolean isNoRecoveryException(Throwable throwable) {
+		return this.noRecoveryForNotRetryableExceptions != null
+				&& Arrays.asList(this.noRecoveryForNotRetryableExceptions).contains(throwable.getClass());
 	}
 
 	private <T, E extends Throwable> boolean doOpenInterceptors(RetryCallback<T, E> callback, RetryContext context) {

--- a/src/main/java/org/springframework/retry/support/RetryTemplate.java
+++ b/src/main/java/org/springframework/retry/support/RetryTemplate.java
@@ -610,8 +610,15 @@ public class RetryTemplate implements RetryOperations {
 	}
 
 	private boolean isNoRecoveryException(Throwable throwable) {
-		return this.noRecoveryForNotRetryableExceptions != null
-				&& Arrays.asList(this.noRecoveryForNotRetryableExceptions).contains(throwable.getClass());
+		if (this.noRecoveryForNotRetryableExceptions == null) {
+			return false;
+		}
+		for (Class<? extends Throwable> t : noRecoveryForNotRetryableExceptions) {
+			if (t.isAssignableFrom(throwable.getClass())) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	private <T, E extends Throwable> boolean doOpenInterceptors(RetryCallback<T, E> callback, RetryContext context) {

--- a/src/main/java/org/springframework/retry/support/RetryTemplate.java
+++ b/src/main/java/org/springframework/retry/support/RetryTemplate.java
@@ -98,8 +98,6 @@ public class RetryTemplate implements RetryOperations {
 
 	private boolean noRecoveryForNotRetryable;
 
-	private Class<? extends Throwable>[] noRecoveryForNotRetryableExceptions;
-
 	/**
 	 * Main entry point to configure RetryTemplate using fluent API. See
 	 * {@link RetryTemplateBuilder} for usage examples and details.
@@ -138,20 +136,6 @@ public class RetryTemplate implements RetryOperations {
 	 */
 	public void setNoRecoveryForNotRetryable(boolean noRecoveryForNotRetryable) {
 		this.noRecoveryForNotRetryable = noRecoveryForNotRetryable;
-	}
-
-	/**
-	 * Set exception types to not call the recovery callback (if any) when a not-retryable
-	 * exception is thrown by the target code in
-	 * {@link #execute(RetryCallback, RecoveryCallback)}. By default, the callback is
-	 * invoked when retries are exhausted, or immediately for not-retryable exceptions.
-	 * @param noRecoveryForNotRetryableExceptions the noRecoveryForNotRetryableExceptions
-	 * to set
-	 * @since 1.3.3
-	 */
-	public void setNoRecoveryForNotRetryableExceptions(
-			Class<? extends Throwable>... noRecoveryForNotRetryableExceptions) {
-		this.noRecoveryForNotRetryableExceptions = noRecoveryForNotRetryableExceptions;
 	}
 
 	/**
@@ -579,8 +563,7 @@ public class RetryTemplate implements RetryOperations {
 	}
 
 	protected <E extends Throwable> void rethrow(RetryContext context, String message) throws E {
-		if (this.throwLastExceptionOnExhausted || this.noRecoveryForNotRetryable
-				|| isNoRecoveryException(context.getLastThrowable())) {
+		if (this.throwLastExceptionOnExhausted || this.noRecoveryForNotRetryable) {
 			@SuppressWarnings("unchecked")
 			E rethrow = (E) context.getLastThrowable();
 			throw rethrow;
@@ -604,14 +587,8 @@ public class RetryTemplate implements RetryOperations {
 	}
 
 	private boolean shouldRethrowWithoutRecovery(Throwable throwable) {
-		return (this.noRecoveryForNotRetryable || isNoRecoveryException(throwable))
-				&& retryPolicy instanceof SimpleRetryPolicy
+		return this.noRecoveryForNotRetryable && retryPolicy instanceof SimpleRetryPolicy
 				&& !((SimpleRetryPolicy) retryPolicy).retryForException(throwable);
-	}
-
-	private boolean isNoRecoveryException(Throwable throwable) {
-		return this.noRecoveryForNotRetryableExceptions != null
-				&& Arrays.asList(this.noRecoveryForNotRetryableExceptions).contains(throwable.getClass());
 	}
 
 	private <T, E extends Throwable> boolean doOpenInterceptors(RetryCallback<T, E> callback, RetryContext context) {

--- a/src/test/java/org/springframework/classify/SubclassClassifierTests.java
+++ b/src/test/java/org/springframework/classify/SubclassClassifierTests.java
@@ -16,8 +16,8 @@
 
 package org.springframework.classify;
 
-import java.util.Collections;
-import java.util.function.Supplier;
+//import java.util.Collections;
+//import java.util.function.Supplier;
 
 import org.junit.Test;
 
@@ -25,31 +25,35 @@ import static org.junit.Assert.assertEquals;
 
 public class SubclassClassifierTests {
 
-	@Test
-	public void testClassifyInterface() {
-		SubclassClassifier<Object, String> classifier = new SubclassClassifier<Object, String>();
-		classifier.setTypeMap(Collections.<Class<?>, String>singletonMap(Supplier.class, "foo"));
-		assertEquals("foo", classifier.classify(new Foo()));
-	}
-
-	@Test
-	public void testClassifyInterfaceOfParent() {
-		SubclassClassifier<Object, String> classifier = new SubclassClassifier<Object, String>();
-		classifier.setTypeMap(Collections.<Class<?>, String>singletonMap(Supplier.class, "foo"));
-		assertEquals("foo", classifier.classify(new Bar()));
-	}
-
-	public class Bar extends Foo {
-
-	}
-
-	public static class Foo implements Supplier<String> {
-
-		@Override
-		public String get() {
-			return "foo";
-		}
-
-	}
+	// @Test
+	// public void testClassifyInterface() {
+	// SubclassClassifier<Object, String> classifier = new SubclassClassifier<Object,
+	// String>();
+	// classifier.setTypeMap(Collections.<Class<?>, String>singletonMap(Supplier.class,
+	// "foo"));
+	// assertEquals("foo", classifier.classify(new Foo()));
+	// }
+	//
+	// @Test
+	// public void testClassifyInterfaceOfParent() {
+	// SubclassClassifier<Object, String> classifier = new SubclassClassifier<Object,
+	// String>();
+	// classifier.setTypeMap(Collections.<Class<?>, String>singletonMap(Supplier.class,
+	// "foo"));
+	// assertEquals("foo", classifier.classify(new Bar()));
+	// }
+	//
+	// public class Bar extends Foo {
+	//
+	// }
+	//
+	// public static class Foo implements Supplier<String> {
+	//
+	// @Override
+	// public String get() {
+	// return "foo";
+	// }
+	//
+	// }
 
 }

--- a/src/test/java/org/springframework/classify/SubclassClassifierTests.java
+++ b/src/test/java/org/springframework/classify/SubclassClassifierTests.java
@@ -16,8 +16,8 @@
 
 package org.springframework.classify;
 
-//import java.util.Collections;
-//import java.util.function.Supplier;
+import java.util.Collections;
+import java.util.function.Supplier;
 
 import org.junit.Test;
 
@@ -25,35 +25,31 @@ import static org.junit.Assert.assertEquals;
 
 public class SubclassClassifierTests {
 
-	// @Test
-	// public void testClassifyInterface() {
-	// SubclassClassifier<Object, String> classifier = new SubclassClassifier<Object,
-	// String>();
-	// classifier.setTypeMap(Collections.<Class<?>, String>singletonMap(Supplier.class,
-	// "foo"));
-	// assertEquals("foo", classifier.classify(new Foo()));
-	// }
-	//
-	// @Test
-	// public void testClassifyInterfaceOfParent() {
-	// SubclassClassifier<Object, String> classifier = new SubclassClassifier<Object,
-	// String>();
-	// classifier.setTypeMap(Collections.<Class<?>, String>singletonMap(Supplier.class,
-	// "foo"));
-	// assertEquals("foo", classifier.classify(new Bar()));
-	// }
-	//
-	// public class Bar extends Foo {
-	//
-	// }
-	//
-	// public static class Foo implements Supplier<String> {
-	//
-	// @Override
-	// public String get() {
-	// return "foo";
-	// }
-	//
-	// }
+	@Test
+	public void testClassifyInterface() {
+		SubclassClassifier<Object, String> classifier = new SubclassClassifier<Object, String>();
+		classifier.setTypeMap(Collections.<Class<?>, String>singletonMap(Supplier.class, "foo"));
+		assertEquals("foo", classifier.classify(new Foo()));
+	}
+
+	@Test
+	public void testClassifyInterfaceOfParent() {
+		SubclassClassifier<Object, String> classifier = new SubclassClassifier<Object, String>();
+		classifier.setTypeMap(Collections.<Class<?>, String>singletonMap(Supplier.class, "foo"));
+		assertEquals("foo", classifier.classify(new Bar()));
+	}
+
+	public class Bar extends Foo {
+
+	}
+
+	public static class Foo implements Supplier<String> {
+
+		@Override
+		public String get() {
+			return "foo";
+		}
+
+	}
 
 }

--- a/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
+++ b/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
@@ -434,7 +434,7 @@ public class RetryTemplateTests {
 	}
 
 	@Test
-	public void testRethrowExceptionsForNotRetryable() throws Throwable {
+	public void testRethrowForAnotherNotRetryable() throws Throwable {
 		Map<Class<? extends Throwable>, Boolean> retryableExceptions = new HashMap<Class<? extends Throwable>, Boolean>();
 		retryableExceptions.put(IllegalArgumentException.class, true);
 		retryableExceptions.put(IllegalStateException.class, false);
@@ -446,7 +446,7 @@ public class RetryTemplateTests {
 			retryTemplate.execute(new RetryCallback<Object, Exception>() {
 				@Override
 				public Object doWithRetry(RetryContext context) throws Exception {
-					throw new IllegalStateException("Realllly bad!");
+					throw new UnsupportedOperationException("Realllly bad!");
 				}
 			}, new RecoveryCallback<Object>() {
 				@Override
@@ -454,26 +454,25 @@ public class RetryTemplateTests {
 					return new Object();
 				}
 			});
-			fail("Expected RuntimeException");
+			fail("Expected UnsupportedOperationException");
 		}
-		catch (IllegalStateException e) {
+		catch (RuntimeException e) {
 			assertEquals("Realllly bad!", e.getMessage());
 		}
 	}
 
 	@Test
-	public void testRethrowExceptionsForRetryable() throws Throwable {
-		Map<Class<? extends Throwable>, Boolean> retryableExceptions = new HashMap<Class<? extends Throwable>, Boolean>();
-		retryableExceptions.put(IllegalArgumentException.class, true);
-		retryableExceptions.put(IllegalStateException.class, false);
-		SimpleRetryPolicy policy = new SimpleRetryPolicy(1, retryableExceptions);
+	public void testRethrowExceptionsForAnotherNotRetryable() throws Throwable {
+		SimpleRetryPolicy policy = new SimpleRetryPolicy(1,
+				Collections.<Class<? extends Throwable>, Boolean>singletonMap(IllegalArgumentException.class, true));
 		RetryTemplate retryTemplate = new RetryTemplate();
 		retryTemplate.setRetryPolicy(policy);
+		retryTemplate.setNoRecoveryForNotRetryableExceptions(IllegalStateException.class);
 		final Object value = new Object();
 		Object result = retryTemplate.execute(new RetryCallback<Object, Exception>() {
 			@Override
 			public Object doWithRetry(RetryContext context) throws Exception {
-				throw new IllegalStateException("Will be recovered");
+				throw new UnsupportedOperationException("Will be recovered");
 			}
 		}, new RecoveryCallback<Object>() {
 			@Override

--- a/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
+++ b/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
@@ -431,6 +431,54 @@ public class RetryTemplateTests {
 		assertEquals(value, result);
 	}
 
+	@Test
+	public void testRethrowExceptionsForNotRetryable() throws Throwable {
+		SimpleRetryPolicy policy = new SimpleRetryPolicy(1,
+				Collections.<Class<? extends Throwable>, Boolean>singletonMap(IllegalArgumentException.class, true));
+		RetryTemplate retryTemplate = new RetryTemplate();
+		retryTemplate.setRetryPolicy(policy);
+		retryTemplate.setNoRecoveryForNotRetryableExceptions(IllegalStateException.class);
+		try {
+			retryTemplate.execute(new RetryCallback<Object, Exception>() {
+				@Override
+				public Object doWithRetry(RetryContext context) throws Exception {
+					throw new IllegalStateException("Realllly bad!");
+				}
+			}, new RecoveryCallback<Object>() {
+				@Override
+				public Object recover(RetryContext context) throws Exception {
+					return new Object();
+				}
+			});
+			fail("Expected RuntimeException");
+		}
+		catch (IllegalStateException e) {
+			assertEquals("Realllly bad!", e.getMessage());
+		}
+	}
+
+	@Test
+	public void testRethrowExceptionsForRetryable() throws Throwable {
+		SimpleRetryPolicy policy = new SimpleRetryPolicy(1,
+				Collections.<Class<? extends Throwable>, Boolean>singletonMap(IllegalStateException.class, true));
+		RetryTemplate retryTemplate = new RetryTemplate();
+		retryTemplate.setRetryPolicy(policy);
+		retryTemplate.setNoRecoveryForNotRetryableExceptions(IllegalStateException.class);
+		final Object value = new Object();
+		Object result = retryTemplate.execute(new RetryCallback<Object, Exception>() {
+			@Override
+			public Object doWithRetry(RetryContext context) throws Exception {
+				throw new IllegalStateException("Will be recovered");
+			}
+		}, new RecoveryCallback<Object>() {
+			@Override
+			public Object recover(RetryContext context) throws Exception {
+				return value;
+			}
+		});
+		assertEquals(value, result);
+	}
+
 	private static class MockRetryCallback implements RetryCallback<Object, Exception> {
 
 		private int attempts;

--- a/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
+++ b/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
@@ -17,6 +17,8 @@
 package org.springframework.retry.support;
 
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.Test;
@@ -433,11 +435,13 @@ public class RetryTemplateTests {
 
 	@Test
 	public void testRethrowExceptionsForNotRetryable() throws Throwable {
-		SimpleRetryPolicy policy = new SimpleRetryPolicy(1,
-				Collections.<Class<? extends Throwable>, Boolean>singletonMap(IllegalArgumentException.class, true));
+		Map<Class<? extends Throwable>, Boolean> retryableExceptions = new HashMap<Class<? extends Throwable>, Boolean>();
+		retryableExceptions.put(IllegalArgumentException.class, true);
+		retryableExceptions.put(IllegalStateException.class, false);
+		SimpleRetryPolicy policy = new SimpleRetryPolicy(1, retryableExceptions);
 		RetryTemplate retryTemplate = new RetryTemplate();
 		retryTemplate.setRetryPolicy(policy);
-		retryTemplate.setNoRecoveryForNotRetryableExceptions(IllegalStateException.class);
+		retryTemplate.setNoRecoveryForNotRetryable(true);
 		try {
 			retryTemplate.execute(new RetryCallback<Object, Exception>() {
 				@Override
@@ -459,11 +463,12 @@ public class RetryTemplateTests {
 
 	@Test
 	public void testRethrowExceptionsForRetryable() throws Throwable {
-		SimpleRetryPolicy policy = new SimpleRetryPolicy(1,
-				Collections.<Class<? extends Throwable>, Boolean>singletonMap(IllegalStateException.class, true));
+		Map<Class<? extends Throwable>, Boolean> retryableExceptions = new HashMap<Class<? extends Throwable>, Boolean>();
+		retryableExceptions.put(IllegalArgumentException.class, true);
+		retryableExceptions.put(IllegalStateException.class, false);
+		SimpleRetryPolicy policy = new SimpleRetryPolicy(1, retryableExceptions);
 		RetryTemplate retryTemplate = new RetryTemplate();
 		retryTemplate.setRetryPolicy(policy);
-		retryTemplate.setNoRecoveryForNotRetryableExceptions(IllegalStateException.class);
 		final Object value = new Object();
 		Object result = retryTemplate.execute(new RetryCallback<Object, Exception>() {
 			@Override


### PR DESCRIPTION
Although `rethrow` helps a lot I have use-cases where I need exception handling to be even more flexible.

- Rethrow particular not-retryable exceptions without recovering and wrapping them: `rethrowExceptions`

**Example:**
I want to retry server exceptions except for an authorization exception as this should be sent immediately and directly to the caller. 

```java
@Retry(include={ServerException.class}, rethrowExceptions={AuthorizationException.class})
public String makeSomeCall() { … }

@Recover
private String recoverThatCall(Throwable t) {
    // not for AuthorizationException
}
```
