### PR TITLE
GH-231: Support Retry Based on Result

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,7 +362,7 @@ The type of the exception thrown is then used to determine whether the call shou
 If there has been an error, it is the last one thrown by the `RetryCallback`.
 
 Note that when there is more than one listener, they are in a list, so there is an order.
-In this case, `open` is called in the same order, while `onSuccess`, `onError`, and `close` are called in reverse order
+In this case, `open` is called in the same order, while `onSuccess`, `onError`, and `close` are called in reverse order.
 
 `RetryListenerSupport` is provided, with no-op implementations; you can extend this class if you don't need to implement all of the `RetryListener` methods.
 

--- a/src/main/java/org/springframework/retry/RetryListener.java
+++ b/src/main/java/org/springframework/retry/RetryListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ package org.springframework.retry;
  * lifecycle.
  *
  * @author Dave Syer
+ * @author Gary Russell
  *
  */
 public interface RetryListener {
@@ -40,8 +41,8 @@ public interface RetryListener {
 	<T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback);
 
 	/**
-	 * Called after the final attempt (successful or not). Allow the interceptor to clean
-	 * up any resource it is holding before control returns to the retry caller.
+	 * Called after the final attempt (successful or not). Allow the listener to clean up
+	 * any resource it is holding before control returns to the retry caller.
 	 * @param context the current {@link RetryContext}.
 	 * @param callback the current {@link RetryCallback}.
 	 * @param throwable the last exception that was thrown by the callback.
@@ -49,6 +50,19 @@ public interface RetryListener {
 	 * @param <T> the return value
 	 */
 	<T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback, Throwable throwable);
+
+	/**
+	 * Called after a successful attempt; allow the listener to throw a new exception to
+	 * cause a retry (according to the retry policy), based on the result returned by the
+	 * {@link RetryCallback#doWithRetry(RetryContext)}
+	 * @param <T> the return type.
+	 * @param context the current {@link RetryContext}.
+	 * @param callback the current {@link RetryCallback}.
+	 * @param result the result returned by the callback method.
+	 * @since 2.0
+	 */
+	default <T, E extends Throwable> void onSuccess(RetryContext context, RetryCallback<T, E> callback, T result) {
+	}
 
 	/**
 	 * Called after every unsuccessful attempt at a retry.

--- a/src/main/java/org/springframework/retry/support/RetryTemplate.java
+++ b/src/main/java/org/springframework/retry/support/RetryTemplate.java
@@ -326,7 +326,9 @@ public class RetryTemplate implements RetryOperations {
 					// Reset the last exception, so if we are successful
 					// the close interceptors will not think we failed...
 					lastException = null;
-					return retryCallback.doWithRetry(context);
+					T result = retryCallback.doWithRetry(context);
+					doOnSuccessInterceptors(retryCallback, context, result);
+					return result;
 				}
 				catch (Throwable e) {
 
@@ -587,6 +589,13 @@ public class RetryTemplate implements RetryOperations {
 			Throwable lastException) {
 		for (int i = this.listeners.length; i-- > 0;) {
 			this.listeners[i].close(context, callback, lastException);
+		}
+	}
+
+	private <T, E extends Throwable> void doOnSuccessInterceptors(RetryCallback<T, E> callback, RetryContext context,
+			T result) {
+		for (int i = this.listeners.length; i-- > 0;) {
+			this.listeners[i].onSuccess(context, callback, result);
 		}
 	}
 

--- a/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
@@ -129,9 +129,11 @@ public class RetryOperationsInterceptorTests {
 		final String methodTagName = "method";
 		final String labelTagName = "label";
 		final Map<String, String> monitoringTags = new HashMap<>();
+		AtomicBoolean argumentsAsExpected = new AtomicBoolean();
 		RetryTemplate template = new RetryTemplate();
 		template.setRetryPolicy(new SimpleRetryPolicy(2));
 		template.registerListener(new MethodInvocationRetryListenerSupport() {
+
 			@Override
 			protected <T, E extends Throwable> void doClose(RetryContext context,
 					MethodInvocationRetryCallback<T, E> callback, Throwable throwable) {
@@ -140,6 +142,14 @@ public class RetryOperationsInterceptorTests {
 				monitoringTags.put(classTagName, method.getDeclaringClass().getSimpleName());
 				monitoringTags.put(methodTagName, method.getName());
 			}
+
+			@Override
+			protected <T, E extends Throwable> void doOnSuccess(RetryContext context,
+					MethodInvocationRetryCallback<T, E> callback, T result) {
+
+				argumentsAsExpected.set(callback.getInvocation().getArguments().length == 0);
+			}
+
 		});
 
 		this.interceptor.setLabel(label);
@@ -153,6 +163,7 @@ public class RetryOperationsInterceptorTests {
 		assertThat(monitoringTags.get(classTagName),
 				equalTo(RetryOperationsInterceptorTests.Service.class.getSimpleName()));
 		assertThat(monitoringTags.get(methodTagName), equalTo("service"));
+		assertTrue(argumentsAsExpected.get());
 	}
 
 	@Test


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-retry/issues/231

Enhance `RetryListener` to allow it to examine the result to determine
whether the call should be accepted, or retried according to the retry
policy.