### PR TITLE
GH-299: Fix @Recover with Class Level @Retryable

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -174,7 +174,7 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 			MethodInterceptor interceptor = NULL_INTERCEPTOR;
 			Retryable retryable = AnnotatedElementUtils.findMergedAnnotation(method, Retryable.class);
 			if (retryable == null) {
-				retryable = AnnotatedElementUtils.findMergedAnnotation(method.getDeclaringClass(), Retryable.class);
+				retryable = classLevelAnnotation(method, Retryable.class);
 			}
 			if (retryable == null) {
 				retryable = findAnnotationOnTarget(target, method, Retryable.class);
@@ -203,7 +203,7 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 			Method targetMethod = target.getClass().getMethod(method.getName(), method.getParameterTypes());
 			A retryable = AnnotatedElementUtils.findMergedAnnotation(targetMethod, annotation);
 			if (retryable == null) {
-				retryable = AnnotatedElementUtils.findMergedAnnotation(targetMethod.getDeclaringClass(), annotation);
+				retryable = classLevelAnnotation(targetMethod, annotation);
 			}
 
 			return retryable;
@@ -211,6 +211,17 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 		catch (Exception e) {
 			return null;
 		}
+	}
+
+	/*
+	 * With a class level annotation, exclude @Recover methods.
+	 */
+	private <A extends Annotation> A classLevelAnnotation(Method method, Class<A> annotation) {
+		A ann = AnnotatedElementUtils.findMergedAnnotation(method.getDeclaringClass(), annotation);
+		if (ann != null && AnnotatedElementUtils.findMergedAnnotation(method, Recover.class) != null) {
+			ann = null;
+		}
+		return ann;
 	}
 
 	private MethodInterceptor getStatelessInterceptor(Object target, Method method, Retryable retryable) {

--- a/src/test/java/org/springframework/retry/annotation/DontRetryRecovererTests.java
+++ b/src/test/java/org/springframework/retry/annotation/DontRetryRecovererTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.annotation;
+
+import org.junit.jupiter.api.Test;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+
+/**
+ * @author Gary Russell
+ * @since 1.3.4
+ */
+@SpringJUnitConfig
+public class DontRetryRecovererTests {
+
+	@Test
+	void dontRetry(@Autowired Service service) {
+		assertThatExceptionOfType(RuntimeException.class).isThrownBy(() -> service.foo("x")).withMessage("test");
+		assertThat(service.getCallCount()).isEqualTo(3);
+		assertThat(service.getRecoverCount()).isEqualTo(1);
+	}
+
+	@Configuration
+	@EnableRetry
+	public static class Config {
+
+		@Bean
+		Service service() {
+			return new Service();
+		}
+
+	}
+
+	@Retryable
+	public static class Service {
+
+		int callCount;
+
+		int recoverCount;
+
+		public void foo(String in) {
+			callCount++;
+			throw new RuntimeException();
+		}
+
+		@Recover
+		public void recover(Exception ex, String in) {
+			this.recoverCount++;
+			throw new RuntimeException("test");
+		}
+
+		public int getCallCount() {
+			return callCount;
+		}
+
+		public int getRecoverCount() {
+			return recoverCount;
+		}
+
+	}
+
+}


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-retry/issues/299

Caused by the fix for #244, recover methods should not be considered
as retryable, with class level annotation.

**cherry-pick to 1.3.x**