### PR TITLE
Allow composing `@Retryable` annotation with @AliasFor recover method 

### DIFF
--- a/README.md
+++ b/README.md
@@ -660,7 +660,7 @@ Starting from version 1.3.2 and later `@Retryable` annotation can be used in cus
 For example if you discover you need two kinds of retry strategy, one for local services calls, and one for remote services calls, you could decide
 to create two custom annotations `@LocalRetryable` and `@RemoteRetryable` that differs in the retry strategy as well in the maximum number of retries.
 
-With version 2.0 and later it is also possible to use `@AliasFor` annotation on the `recover` method also, so that you can further extend the versatility of your custom annotations and allow the `recover` argument value
+To make custom annotation composition work properly you can use `@AliasFor` annotation, for example on the `recover` method, so that you can further extend the versatility of your custom annotations and allow the `recover` argument value
 to be picked up as if it was set on the `recover` method of the base `@Retryable` annotation.
 
 Usage Example:

--- a/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
+++ b/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
@@ -30,7 +30,6 @@ import org.springframework.retry.interceptor.MethodInvocationRecoverer;
 import org.springframework.retry.support.RetrySynchronizationManager;
 import org.springframework.util.ClassUtils;
 import org.springframework.util.ReflectionUtils;
-import org.springframework.util.ReflectionUtils.MethodCallback;
 import org.springframework.util.StringUtils;
 
 /**
@@ -53,6 +52,7 @@ import org.springframework.util.StringUtils;
  * @author Maksim Kita
  * @author Gary Russell
  * @author Artem Bilan
+ * @author Gianluca Medici
  */
 public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationRecoverer<T> {
 

--- a/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
+++ b/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.springframework.classify.SubclassClassifier;
-import org.springframework.core.annotation.AnnotationUtils;
+import org.springframework.core.annotation.AnnotatedElementUtils;
 import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.interceptor.MethodInvocationRecoverer;
@@ -196,12 +196,12 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 	private void init(final Object target, Method method) {
 		final Map<Class<? extends Throwable>, Method> types = new HashMap<>();
 		final Method failingMethod = method;
-		Retryable retryable = AnnotationUtils.findAnnotation(method, Retryable.class);
+		Retryable retryable = AnnotatedElementUtils.findMergedAnnotation(method, Retryable.class);
 		if (retryable != null) {
 			this.recoverMethodName = retryable.recover();
 		}
 		ReflectionUtils.doWithMethods(target.getClass(), candidate -> {
-			Recover recover = AnnotationUtils.findAnnotation(candidate, Recover.class);
+			Recover recover = AnnotatedElementUtils.findMergedAnnotation(candidate, Recover.class);
 			if (recover == null) {
 				recover = findAnnotationOnTarget(target, candidate);
 			}
@@ -270,7 +270,7 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 	private Recover findAnnotationOnTarget(Object target, Method method) {
 		try {
 			Method targetMethod = target.getClass().getMethod(method.getName(), method.getParameterTypes());
-			return AnnotationUtils.findAnnotation(targetMethod, Recover.class);
+			return AnnotatedElementUtils.findMergedAnnotation(targetMethod, Recover.class);
 		}
 		catch (Exception e) {
 			return null;

--- a/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
@@ -16,6 +16,7 @@
 
 package org.springframework.retry.annotation;
 
+import java.lang.annotation.*;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -24,6 +25,7 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
+import org.springframework.core.annotation.AliasFor;
 import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.util.CollectionUtils;
 import org.springframework.util.ReflectionUtils;
@@ -276,6 +278,14 @@ public class RecoverAnnotationRecoveryHandlerTests {
 		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
 				new RecoverByRetryableNameWithPrimitiveArgs(), foo);
 		assertThat(handler.recover(new Object[] { 2 }, new RuntimeException("Planned"))).isEqualTo(2);
+	}
+
+	@Test
+	public void recoverByComposedRetryableAnnotationName() {
+		Method foo = ReflectionUtils.findMethod(RecoverByComposedRetryableAnnotationName.class, "foo", String.class);
+		RecoverAnnotationRecoveryHandler<?> handler = new RecoverAnnotationRecoveryHandler<Integer>(
+				new RecoverByComposedRetryableAnnotationName(), foo);
+		assertThat(handler.recover(new Object[] { "Kevin" }, new RuntimeException("Planned"))).isEqualTo(4);
 	}
 
 	private static class InAccessibleRecover {
@@ -634,6 +644,23 @@ public class RecoverAnnotationRecoveryHandlerTests {
 
 	}
 
+	protected static class RecoverByComposedRetryableAnnotationName
+			implements RecoverByComposedRetryableAnnotationNameInterface {
+
+		public int foo(String name) {
+			return 0;
+		}
+
+		public int fooRecover(Throwable throwable, String name) {
+			return 1;
+		}
+
+		public int barRecover(Throwable throwable, String name) {
+			return 2;
+		}
+
+	}
+
 	protected interface RecoverByRetryableNameInterface {
 
 		@Retryable(recover = "barRecover")
@@ -674,6 +701,30 @@ public class RecoverAnnotationRecoveryHandlerTests {
 
 		@Recover
 		public int barRecover(Throwable throwable, int number);
+
+	}
+
+	protected interface RecoverByComposedRetryableAnnotationNameInterface {
+
+		@ComposedRetryable(recover = "barRecover")
+		public int foo(String name);
+
+		@Recover
+		public int fooRecover(Throwable throwable, String name);
+
+		@Recover
+		public int barRecover(Throwable throwable, String name);
+
+	}
+
+	@Target({ ElementType.METHOD, ElementType.TYPE })
+	@Retention(RetentionPolicy.RUNTIME)
+	@Documented
+	@Retryable(maxAttempts = 4)
+	public @interface ComposedRetryable {
+
+		@AliasFor(annotation = Retryable.class, attribute = "recover")
+		String recover() default "";
 
 	}
 

--- a/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandlerTests.java
@@ -16,7 +16,11 @@
 
 package org.springframework.retry.annotation;
 
-import java.lang.annotation.*;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -39,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
  * @author Randell Callahan
  * @author Nathanaël Roberts
  * @author Maksim Kita
+ * @Author Gianluca Medici
  */
 public class RecoverAnnotationRecoveryHandlerTests {
 


### PR DESCRIPTION
Creating a custom annotation composing `@Retryable` will not get the actual recover argument value even when the recover method is annotated with `@AliasFor`. Eg:

```
@Target({ ElementType.METHOD, ElementType.TYPE })
@Retention(RetentionPolicy.RUNTIME)
@Documented
@Retryable(maxAttempts = 4)
public @interface ComposedRetryable {
    @AliasFor(annotation = Retryable.class, attribute = "recover")
    String recover() default "";
}
```

The reason is that `RecoverAnnotationRecoveryHandler` is still using AnnotationUtils.findAnnotation() instead of AnnotatedElementUtils.findMergedAnnotation()