### PR TITLE
Annotate `@EnableRetry` with `@AliasFor`

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/EnableRetry.java
+++ b/src/main/java/org/springframework/retry/annotation/EnableRetry.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2013 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@ import java.lang.annotation.Target;
 
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.AliasFor;
 
 /**
  * Global enabler for <code>@Retryable</code> annotations in Spring beans. If this is
@@ -47,6 +48,7 @@ public @interface EnableRetry {
 	 * standard Java interface-based proxies. The default is {@code false}.
 	 * @return whether to proxy or not to proxy the class
 	 */
+	@AliasFor(annotation = EnableAspectJAutoProxy.class)
 	boolean proxyTargetClass() default false;
 
 }


### PR DESCRIPTION
Any Spring application that uses the annotation `@EnableRetry` with Spring Framework 6.0.0 and Spring Retry 2.0.0 logs the following warning on start-up:

> WARN org.springframework.core.annotation.AnnotationTypeMapping [main] : Support for convention-based annotation attribute overrides is deprecated and will be removed in Spring Framework 6.1. Please annotate the following attributes in @org.springframework.retry.annotation.EnableRetry with appropriate @AliasFor declarations: [proxyTargetClass]

This PR does what the warning kindly asks for.

The warning can be seen easiest when executing `EnableRetryTests`.

I've also assembled a reproducer. It's a plain Spring Boot app with the annotation: https://github.com/hpoettker/alias-demo
