### PR TITLE
Add default implementations to `RetryListener`

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,8 +364,6 @@ If there has been an error, it is the last one thrown by the `RetryCallback`.
 Note that when there is more than one listener, they are in a list, so there is an order.
 In this case, `open` is called in the same order, while `onSuccess`, `onError`, and `close` are called in reverse order.
 
-`RetryListenerSupport` is provided, with no-op implementations; you can extend this class if you don't need to implement all of the `RetryListener` methods.
-
 ### Listeners for Reflective Method Invocations
 
 When dealing with methods that are annotated with `@Retryable` or with Spring AOP intercepted methods, Spring Retry allows a detailed inspection of the method invocation within the `RetryListener` implementation.

--- a/src/main/java/org/springframework/retry/RetryListener.java
+++ b/src/main/java/org/springframework/retry/RetryListener.java
@@ -23,6 +23,7 @@ package org.springframework.retry;
  *
  * @author Dave Syer
  * @author Gary Russell
+ * @author Henning Pöttker
  *
  */
 public interface RetryListener {
@@ -38,7 +39,9 @@ public interface RetryListener {
 	 * @param callback the current {@link RetryCallback}.
 	 * @return true if the retry should proceed.
 	 */
-	<T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback);
+	default <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
+		return true;
+	}
 
 	/**
 	 * Called after the final attempt (successful or not). Allow the listener to clean up
@@ -49,7 +52,9 @@ public interface RetryListener {
 	 * @param <E> the exception type
 	 * @param <T> the return value
 	 */
-	<T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback, Throwable throwable);
+	default <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
+			Throwable throwable) {
+	}
 
 	/**
 	 * Called after a successful attempt; allow the listener to throw a new exception to
@@ -72,6 +77,8 @@ public interface RetryListener {
 	 * @param <T> the return value
 	 * @param <E> the exception to throw
 	 */
-	<T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback, Throwable throwable);
+	default <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
+			Throwable throwable) {
+	}
 
 }

--- a/src/main/java/org/springframework/retry/listener/RetryListenerSupport.java
+++ b/src/main/java/org/springframework/retry/listener/RetryListenerSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2007 the original author or authors.
+ * Copyright 2006-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -24,8 +24,10 @@ import org.springframework.retry.RetryListener;
  * Empty method implementation of {@link RetryListener}.
  *
  * @author Dave Syer
- *
+ * @author Henning Pöttker
+ * @deprecated in favor of the default implementations in {@link RetryListener}
  */
+@Deprecated(since = "2.0.1", forRemoval = true)
 public class RetryListenerSupport implements RetryListener {
 
 	public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,

--- a/src/main/java/org/springframework/retry/stats/StatisticsListener.java
+++ b/src/main/java/org/springframework/retry/stats/StatisticsListener.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2012-2015 the original author or authors.
+ * Copyright 2012-2022 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,15 +19,16 @@ package org.springframework.retry.stats;
 import org.springframework.core.AttributeAccessor;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
 import org.springframework.retry.RetryStatistics;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.policy.CircuitBreakerRetryPolicy;
 
 /**
  * @author Dave Syer
+ * @author Henning Pöttker
  *
  */
-public class StatisticsListener extends RetryListenerSupport {
+public class StatisticsListener implements RetryListener {
 
 	private final StatisticsRepository repository;
 

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
@@ -39,7 +39,6 @@ import org.springframework.retry.RetryListener;
 import org.springframework.retry.backoff.ExponentialBackOffPolicy;
 import org.springframework.retry.backoff.Sleeper;
 import org.springframework.retry.interceptor.RetryInterceptorBuilder;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
 
@@ -57,6 +56,7 @@ import static org.mockito.Mockito.verify;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Aldo Sinanaj
+ * @author Henning Pöttker
  * @since 1.1
  */
 public class EnableRetryTests {
@@ -910,7 +910,7 @@ public class EnableRetryTests {
 
 	}
 
-	public abstract static class OrderedListener extends RetryListenerSupport implements Ordered {
+	public abstract static class OrderedListener implements RetryListener, Ordered {
 
 	}
 

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryWithListenersTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryWithListenersTests.java
@@ -24,13 +24,13 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryListener;
-import org.springframework.retry.listener.RetryListenerSupport;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Dave Syer
  * @author Gary Russell
+ * @author Henning Pöttker
  *
  */
 public class EnableRetryWithListenersTests {
@@ -68,7 +68,7 @@ public class EnableRetryWithListenersTests {
 
 		@Bean
 		public RetryListener listener() {
-			return new RetryListenerSupport() {
+			return new RetryListener() {
 				@Override
 				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
 						Throwable throwable) {
@@ -94,7 +94,7 @@ public class EnableRetryWithListenersTests {
 
 		@Bean
 		public RetryListener listener1() {
-			return new RetryListenerSupport() {
+			return new RetryListener() {
 				@Override
 				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
 						Throwable throwable) {
@@ -105,7 +105,7 @@ public class EnableRetryWithListenersTests {
 
 		@Bean
 		public RetryListener listener2() {
-			return new RetryListenerSupport() {
+			return new RetryListener() {
 				@Override
 				public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
 						Throwable throwable) {

--- a/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
@@ -35,8 +35,8 @@ import org.springframework.aop.target.SingletonTargetSource;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
 import org.springframework.retry.listener.MethodInvocationRetryListenerSupport;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.RetryTemplate;
@@ -47,6 +47,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
 
+/**
+ * @author Dave Syer
+ * @author Marius Grama
+ * @author Gary Russell
+ * @author Stéphane Nicoll
+ * @author Henning Pöttker
+ */
 public class RetryOperationsInterceptorTests {
 
 	private static int count;
@@ -66,7 +73,7 @@ public class RetryOperationsInterceptorTests {
 		this.interceptor = new RetryOperationsInterceptor();
 		RetryTemplate retryTemplate = new RetryTemplate();
 		final AtomicBoolean calledFirst = new AtomicBoolean();
-		retryTemplate.registerListener(new RetryListenerSupport() {
+		retryTemplate.registerListener(new RetryListener() {
 
 			@Override
 			public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
@@ -83,7 +90,7 @@ public class RetryOperationsInterceptorTests {
 			}
 
 		});
-		retryTemplate.registerListener(new RetryListenerSupport() {
+		retryTemplate.registerListener(new RetryListener() {
 
 			@Override
 			public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {

--- a/src/test/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptorTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptorTests.java
@@ -32,8 +32,8 @@ import org.springframework.aop.target.SingletonTargetSource;
 import org.springframework.retry.ExhaustedRetryException;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
 import org.springframework.retry.RetryOperations;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.policy.AlwaysRetryPolicy;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
@@ -51,6 +51,7 @@ import static org.mockito.Mockito.when;
 /**
  * @author Dave Syer
  * @author Gary Russell
+ * @author Henning Pöttker
  *
  */
 public class StatefulRetryOperationsInterceptorTests {
@@ -70,7 +71,7 @@ public class StatefulRetryOperationsInterceptorTests {
 	@BeforeEach
 	public void setUp() {
 		interceptor = new StatefulRetryOperationsInterceptor();
-		retryTemplate.registerListener(new RetryListenerSupport() {
+		retryTemplate.registerListener(new RetryListener() {
 			@Override
 			public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
 					Throwable throwable) {

--- a/src/test/java/org/springframework/retry/listener/RetryListenerSupportTests.java
+++ b/src/test/java/org/springframework/retry/listener/RetryListenerSupportTests.java
@@ -21,6 +21,12 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNoException;
 
+/**
+ * @author Dave Syer
+ * @author Gary Russell
+ * @author Henning Pöttker
+ */
+@SuppressWarnings("deprecation")
 public class RetryListenerSupportTests {
 
 	@Test

--- a/src/test/java/org/springframework/retry/listener/RetryListenerTests.java
+++ b/src/test/java/org/springframework/retry/listener/RetryListenerTests.java
@@ -31,7 +31,14 @@ import org.springframework.retry.support.RetryTemplate;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.assertj.core.api.Assertions.assertThatNoException;
 
+/**
+ * @author Dave Syer
+ * @author Stéphane Nicoll
+ * @author Gary Russell
+ * @author Henning Pöttker
+ */
 public class RetryListenerTests {
 
 	RetryTemplate template = new RetryTemplate();
@@ -41,14 +48,42 @@ public class RetryListenerTests {
 	List<String> list = new ArrayList<>();
 
 	@Test
+	public void testOpenDefaultImplementation() {
+		var retryListener = new RetryListener() {
+		};
+		assertThat(retryListener.open(null, null)).isTrue();
+	}
+
+	@Test
+	public void testCloseDefaultImplementation() {
+		var retryListener = new RetryListener() {
+		};
+		assertThatNoException().isThrownBy(() -> retryListener.close(null, null, null));
+	}
+
+	@Test
+	public void testOnSuccessDefaultImplementation() {
+		var retryListener = new RetryListener() {
+		};
+		assertThatNoException().isThrownBy(() -> retryListener.onError(null, null, null));
+	}
+
+	@Test
+	public void testOnErrorDefaultImplementation() {
+		var retryListener = new RetryListener() {
+		};
+		assertThatNoException().isThrownBy(() -> retryListener.onError(null, null, null));
+	}
+
+	@Test
 	public void testOpenInterceptors() {
-		template.setListeners(new RetryListener[] { new RetryListenerSupport() {
+		template.setListeners(new RetryListener[] { new RetryListener() {
 			public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
 				count++;
 				list.add("1:" + count);
 				return true;
 			}
-		}, new RetryListenerSupport() {
+		}, new RetryListener() {
 			public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
 				count++;
 				list.add("2:" + count);
@@ -63,7 +98,7 @@ public class RetryListenerTests {
 
 	@Test
 	public void testOpenCanVetoRetry() {
-		template.registerListener(new RetryListenerSupport() {
+		template.registerListener(new RetryListener() {
 			public <T, E extends Throwable> boolean open(RetryContext context, RetryCallback<T, E> callback) {
 				list.add("1");
 				return false;
@@ -80,13 +115,13 @@ public class RetryListenerTests {
 
 	@Test
 	public void testCloseInterceptors() {
-		template.setListeners(new RetryListener[] { new RetryListenerSupport() {
+		template.setListeners(new RetryListener[] { new RetryListener() {
 			public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
 					Throwable t) {
 				count++;
 				list.add("1:" + count);
 			}
-		}, new RetryListenerSupport() {
+		}, new RetryListener() {
 			public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
 					Throwable t) {
 				count++;
@@ -103,12 +138,12 @@ public class RetryListenerTests {
 	@Test
 	public void testOnError() {
 		template.setRetryPolicy(new NeverRetryPolicy());
-		template.setListeners(new RetryListener[] { new RetryListenerSupport() {
+		template.setListeners(new RetryListener[] { new RetryListener() {
 			public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
 					Throwable throwable) {
 				list.add("1");
 			}
-		}, new RetryListenerSupport() {
+		}, new RetryListener() {
 			public <T, E extends Throwable> void onError(RetryContext context, RetryCallback<T, E> callback,
 					Throwable throwable) {
 				list.add("2");
@@ -128,7 +163,7 @@ public class RetryListenerTests {
 
 	@Test
 	public void testCloseInterceptorsAfterRetry() {
-		template.registerListener(new RetryListenerSupport() {
+		template.registerListener(new RetryListener() {
 			public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
 					Throwable t) {
 				list.add("" + count);

--- a/src/test/java/org/springframework/retry/stats/StatisticsListenerTests.java
+++ b/src/test/java/org/springframework/retry/stats/StatisticsListenerTests.java
@@ -20,9 +20,9 @@ import org.junit.jupiter.api.Test;
 
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
 import org.springframework.retry.RetryState;
 import org.springframework.retry.RetryStatistics;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 import org.springframework.retry.support.DefaultRetryState;
 import org.springframework.retry.support.RetryTemplate;
@@ -31,6 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * @author Dave Syer
+ * @author Henning Pöttker
  *
  */
 public class StatisticsListenerTests {
@@ -42,7 +43,7 @@ public class StatisticsListenerTests {
 	@Test
 	public void testStatelessSuccessful() throws Throwable {
 		RetryTemplate retryTemplate = new RetryTemplate();
-		retryTemplate.setListeners(new RetryListenerSupport[] { listener });
+		retryTemplate.setListeners(new RetryListener[] { listener });
 		for (int x = 1; x <= 10; x++) {
 			MockRetryCallback callback = new MockRetryCallback();
 			callback.setAttemptsBeforeSuccess(x);
@@ -61,7 +62,7 @@ public class StatisticsListenerTests {
 	@Test
 	public void testStatefulSuccessful() {
 		RetryTemplate retryTemplate = new RetryTemplate();
-		retryTemplate.setListeners(new RetryListenerSupport[] { listener });
+		retryTemplate.setListeners(new RetryListener[] { listener });
 		RetryState state = new DefaultRetryState("foo");
 		for (int x = 1; x <= 10; x++) {
 			MockRetryCallback callback = new MockRetryCallback();
@@ -88,7 +89,7 @@ public class StatisticsListenerTests {
 	@Test
 	public void testStatelessUnsuccessful() {
 		RetryTemplate retryTemplate = new RetryTemplate();
-		retryTemplate.setListeners(new RetryListenerSupport[] { listener });
+		retryTemplate.setListeners(new RetryListener[] { listener });
 		for (int x = 1; x <= 10; x++) {
 			MockRetryCallback callback = new MockRetryCallback();
 			callback.setAttemptsBeforeSuccess(x + 1);
@@ -111,7 +112,7 @@ public class StatisticsListenerTests {
 	@Test
 	public void testStatefulUnsuccessful() {
 		RetryTemplate retryTemplate = new RetryTemplate();
-		retryTemplate.setListeners(new RetryListenerSupport[] { listener });
+		retryTemplate.setListeners(new RetryListener[] { listener });
 		RetryState state = new DefaultRetryState("foo");
 		for (int x = 1; x <= 10; x++) {
 			MockRetryCallback callback = new MockRetryCallback();
@@ -138,7 +139,7 @@ public class StatisticsListenerTests {
 	@Test
 	public void testStatelessRecovery() throws Throwable {
 		RetryTemplate retryTemplate = new RetryTemplate();
-		retryTemplate.setListeners(new RetryListenerSupport[] { listener });
+		retryTemplate.setListeners(new RetryListener[] { listener });
 		for (int x = 1; x <= 10; x++) {
 			MockRetryCallback callback = new MockRetryCallback();
 			callback.setAttemptsBeforeSuccess(x + 1);
@@ -157,7 +158,7 @@ public class StatisticsListenerTests {
 	@Test
 	public void testStatefulRecovery() {
 		RetryTemplate retryTemplate = new RetryTemplate();
-		retryTemplate.setListeners(new RetryListenerSupport[] { listener });
+		retryTemplate.setListeners(new RetryListener[] { listener });
 		RetryState state = new DefaultRetryState("foo");
 		for (int x = 1; x <= 10; x++) {
 			MockRetryCallback callback = new MockRetryCallback();

--- a/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
+++ b/src/test/java/org/springframework/retry/support/RetryTemplateTests.java
@@ -25,12 +25,12 @@ import org.junit.jupiter.api.Test;
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
+import org.springframework.retry.RetryListener;
 import org.springframework.retry.TerminatedRetryException;
 import org.springframework.retry.backoff.BackOffContext;
 import org.springframework.retry.backoff.BackOffInterruptedException;
 import org.springframework.retry.backoff.BackOffPolicy;
 import org.springframework.retry.backoff.StatelessBackOffPolicy;
-import org.springframework.retry.listener.RetryListenerSupport;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
 
@@ -48,6 +48,7 @@ import static org.mockito.Mockito.verify;
  * @author Rob Harrop
  * @author Dave Syer
  * @author Gary Russell
+ * @author Henning Pöttker
  */
 public class RetryTemplateTests {
 
@@ -311,7 +312,7 @@ public class RetryTemplateTests {
 	@Test
 	public void testRetryOnBadResult() {
 		RetryTemplate template = new RetryTemplate();
-		template.registerListener(new RetryListenerSupport() {
+		template.registerListener(new RetryListener() {
 
 			@Override
 			public <T, E extends Throwable> void onSuccess(RetryContext context, RetryCallback<T, E> callback,


### PR DESCRIPTION
With Spring Retry 2.0.0, the baseline was lifted from Java 6 to Java 17, which allows to now use default implementations in interfaces.

The only purpose of `RetryListenerSupport` is to provide default implementations for `RetryListener`. As such support implementations are no longer required, this PR deprecates `RetryListenerSupport` and adds its default implementations to `RetryListener`.