### PR TITLE
add notice and license to jar

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2006-2022 the original author or authors.
+Copyright (c) 2006-2023 the original author or authors.
 
 This product is licensed to you under the Apache License, Version 2.0
 (the "License"). You may not use this product except in compliance with

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,0 +1,5 @@
+Copyright (c) 2006-2022 the original author or authors.
+
+This product is licensed to you under the Apache License, Version 2.0
+(the "License"). You may not use this product except in compliance with
+the License.

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,16 @@
 	</dependencies>
 
 	<build>
+		<resources>
+			<resource>
+				<directory>.</directory>
+				<targetPath>META-INF</targetPath>
+				<includes>
+					<include>LICENSE-2.0.txt</include>
+					<include>NOTICE.txt</include>
+				</includes>
+			</resource>
+		</resources>
 		<pluginManagement>
 			<plugins>
 				<plugin>


### PR DESCRIPTION
In many other Spring and Spring Boot projects, the license and notice files are included in the jar file under META-INF. In this Spring project, the two files should also be added to the jar.