### PR TITLE
Add constructor make timeout customisable

### DIFF
--- a/src/main/java/org/springframework/retry/policy/TimeoutRetryPolicy.java
+++ b/src/main/java/org/springframework/retry/policy/TimeoutRetryPolicy.java
@@ -35,7 +35,23 @@ public class TimeoutRetryPolicy implements RetryPolicy {
 	 */
 	public static final long DEFAULT_TIMEOUT = 1000;
 
-	private long timeout = DEFAULT_TIMEOUT;
+	private long timeout;
+
+	/**
+	 * Create a new instance with the timeout set to {@link #DEFAULT_TIMEOUT}.
+	 */
+	public TimeoutRetryPolicy() {
+		this(DEFAULT_TIMEOUT);
+	}
+
+	/**
+	 * Create a new instance with a configurable timeout.
+	 * @param timeout timeout in milliseconds
+	 * @since 2.0.2
+	 */
+	public TimeoutRetryPolicy(long timeout) {
+		this.timeout = timeout;
+	}
 
 	/**
 	 * Setter for timeout in milliseconds. Default is {@link #DEFAULT_TIMEOUT}.

--- a/src/test/java/org/springframework/retry/policy/TimeoutRetryPolicyTests.java
+++ b/src/test/java/org/springframework/retry/policy/TimeoutRetryPolicyTests.java
@@ -57,4 +57,15 @@ public class TimeoutRetryPolicyTests {
 		assertThat(child.getParent()).isSameAs(context);
 	}
 
+	@Test
+	public void testConstructorWithCustomTimeout() throws Exception {
+		TimeoutRetryPolicy policy = new TimeoutRetryPolicy(100);
+		RetryContext context = policy.open(null);
+		policy.registerThrowable(context, new Exception());
+		assertThat(policy.canRetry(context)).isTrue();
+		Thread.sleep(200);
+		assertThat(policy.canRetry(context)).isFalse();
+		policy.close(context);
+	}
+
 }


### PR DESCRIPTION
Adds a separate constructor to `TimeoutRetryPolicy` to create a new instance with a configurable timeout. This follows the pattern established by other policies, for example, `SimpleRetryPolicy`, that allow to customise their behaviour during instance creation.