### PR TITLE
Option to Avoid ThreadLocal Usage (Draft)

### DIFF
--- a/src/main/java/org/springframework/retry/RetryContext.java
+++ b/src/main/java/org/springframework/retry/RetryContext.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2022 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,15 +17,24 @@
 package org.springframework.retry;
 
 import org.springframework.core.AttributeAccessor;
+import org.springframework.retry.support.RetrySynchronizationManager;
 
 /**
  * Low-level access to ongoing retry operation. Normally not needed by clients, but can be
  * used to alter the course of the retry, e.g. force an early termination.
  *
  * @author Dave Syer
+ * @author Gary Russell
  *
  */
 public interface RetryContext extends AttributeAccessor {
+
+	/**
+	 * Retry context attribute name for the key to a map of contexts when not using thread
+	 * locals in {@link RetrySynchronizationManager}.
+	 * @since 2.0.3
+	 */
+	String KEY = "context.key";
 
 	/**
 	 * Retry context attribute name for reporting key. Can be used for reporting purposes,

--- a/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
+++ b/src/main/java/org/springframework/retry/annotation/RecoverAnnotationRecoveryHandler.java
@@ -73,6 +73,11 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 
 	@Override
 	public T recover(Object[] args, Throwable cause) {
+		return recover(RetrySynchronizationManager.getContext(), args, cause);
+	}
+
+	@Override
+	public T recover(RetryContext context, Object[] args, Throwable cause) {
 		Method method = findClosestMatch(args, cause.getClass());
 		if (method == null) {
 			throw new ExhaustedRetryException("Cannot locate recovery method", cause);
@@ -80,7 +85,6 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 		SimpleMetadata meta = this.methods.get(method);
 		Object[] argsToUse = meta.getArgs(cause, args);
 		ReflectionUtils.makeAccessible(method);
-		RetryContext context = RetrySynchronizationManager.getContext();
 		Object proxy = null;
 		if (context != null) {
 			proxy = context.getAttribute("___proxy___");
@@ -288,7 +292,6 @@ public class RecoverAnnotationRecoveryHandler<T> implements MethodInvocationReco
 		}
 		if (filteredMethods.size() > 0) {
 			this.methods.clear();
-			;
 			this.methods.putAll(filteredMethods);
 		}
 	}

--- a/src/main/java/org/springframework/retry/context/RetryContextSupport.java
+++ b/src/main/java/org/springframework/retry/context/RetryContextSupport.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2014 the original author or authors.
+ * Copyright 2006-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,6 +22,7 @@ import org.springframework.retry.RetryPolicy;
 
 /**
  * @author Dave Syer
+ * @author Gary Russell
  */
 @SuppressWarnings("serial")
 public class RetryContextSupport extends AttributeAccessorSupport implements RetryContext {
@@ -37,26 +38,34 @@ public class RetryContextSupport extends AttributeAccessorSupport implements Ret
 	public RetryContextSupport(RetryContext parent) {
 		super();
 		this.parent = parent;
+		if (parent != null) {
+			setAttribute(RetryContext.KEY, parent.getAttribute(RetryContext.KEY));
+		}
 	}
 
+	@Override
 	public RetryContext getParent() {
 		return this.parent;
 	}
 
+	@Override
 	public boolean isExhaustedOnly() {
-		return terminate;
+		return this.terminate;
 	}
 
+	@Override
 	public void setExhaustedOnly() {
-		terminate = true;
+		this.terminate = true;
 	}
 
+	@Override
 	public int getRetryCount() {
-		return count;
+		return this.count;
 	}
 
+	@Override
 	public Throwable getLastThrowable() {
-		return lastException;
+		return this.lastException;
 	}
 
 	/**
@@ -73,14 +82,15 @@ public class RetryContextSupport extends AttributeAccessorSupport implements Ret
 	 */
 	public void registerThrowable(Throwable throwable) {
 		this.lastException = throwable;
-		if (throwable != null)
-			count++;
+		if (throwable != null) {
+			this.count++;
+		}
 	}
 
 	@Override
 	public String toString() {
-		return String.format("[RetryContext: count=%d, lastException=%s, exhausted=%b]", count, lastException,
-				terminate);
+		return String.format("[RetryContext: count=%d, lastException=%s, exhausted=%b]", this.count, this.lastException,
+				this.terminate);
 	}
 
 }

--- a/src/main/java/org/springframework/retry/interceptor/MethodInvocationRecoverer.java
+++ b/src/main/java/org/springframework/retry/interceptor/MethodInvocationRecoverer.java
@@ -16,6 +16,8 @@
 
 package org.springframework.retry.interceptor;
 
+import org.springframework.retry.RetryContext;
+
 /**
  * Strategy interface for recovery action when processing of an item fails.
  *
@@ -31,7 +33,23 @@ public interface MethodInvocationRecoverer<T> {
 	 * @param args the arguments for the method invocation that failed.
 	 * @param cause the cause of the failure that led to this recovery.
 	 * @return the value to be returned to the caller
+	 * @deprecated in favor of {@link #recover(RetryContext, Object[], Throwable)}
 	 */
+	@Deprecated
 	T recover(Object[] args, Throwable cause);
+
+	/**
+	 * Recover gracefully from an error. Clients can call this if processing of the item
+	 * throws an unexpected exception. Caller can use the return value to decide whether
+	 * to try more corrective action or perhaps throw an exception.
+	 * @param context the {@link RetryContext}.
+	 * @param args the arguments for the method invocation that failed.
+	 * @param cause the cause of the failure that led to this recovery.
+	 * @return the value to be returned to the caller
+	 */
+	@SuppressWarnings("deprecation")
+	default T recover(RetryContext context, Object[] args, Throwable cause) {
+		return recover(args, context.getLastThrowable());
+	}
 
 }

--- a/src/test/java/org/springframework/retry/annotation/CircuitBreakerTests.java
+++ b/src/test/java/org/springframework/retry/annotation/CircuitBreakerTests.java
@@ -17,7 +17,7 @@
 package org.springframework.retry.annotation;
 
 import java.util.Map;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.junit.jupiter.api.Test;
@@ -100,18 +100,18 @@ public class CircuitBreakerTests {
 		Map<?, ?> methodMap = (Map<?, ?>) delegates.values().iterator().next();
 		MethodInterceptor interceptor = (MethodInterceptor) methodMap
 			.get(Service.class.getDeclaredMethod("expressionService3"));
-		Supplier<?> maxAttempts = TestUtils.getPropertyValue(interceptor,
-				"retryOperations.retryPolicy.delegate.maxAttemptsSupplier", Supplier.class);
+		Function<?, ?> maxAttempts = TestUtils.getPropertyValue(interceptor,
+				"retryOperations.retryPolicy.delegate.maxAttemptsFunction", Function.class);
 		assertThat(maxAttempts).isNotNull();
-		assertThat(maxAttempts.get()).isEqualTo(10);
+		assertThat(maxAttempts.apply(null)).isEqualTo(10);
 		CircuitBreakerRetryPolicy policy = TestUtils.getPropertyValue(interceptor, "retryOperations.retryPolicy",
 				CircuitBreakerRetryPolicy.class);
-		Supplier openTO = TestUtils.getPropertyValue(policy, "openTimeoutSupplier", Supplier.class);
+		Function<?, ?> openTO = TestUtils.getPropertyValue(policy, "openTimeoutFunction", Function.class);
 		assertThat(openTO).isNotNull();
-		assertThat(openTO.get()).isEqualTo(10000L);
-		Supplier resetTO = TestUtils.getPropertyValue(policy, "resetTimeoutSupplier", Supplier.class);
+		assertThat(openTO.apply(null)).isEqualTo(10000L);
+		Function<?, ?> resetTO = TestUtils.getPropertyValue(policy, "resetTimeoutFunction", Function.class);
 		assertThat(resetTO).isNotNull();
-		assertThat(resetTO.get()).isEqualTo(20000L);
+		assertThat(resetTO.apply(null)).isEqualTo(20000L);
 		RetryContext ctx = service.getContext();
 		assertThat(TestUtils.getPropertyValue(ctx, "openWindow")).isEqualTo(10000L);
 		assertThat(TestUtils.getPropertyValue(ctx, "timeout")).isEqualTo(20000L);

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryNoThreadLocalTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryNoThreadLocalTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.annotation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.retry.support.RetrySynchronizationManager;
+
+public class EnableRetryNoThreadLocalTests extends EnableRetryTests {
+
+	@BeforeAll
+	static void before() {
+		RetrySynchronizationManager.setUseThreadLocal(false);
+	}
+
+	@AfterAll
+	static void after() {
+		RetrySynchronizationManager.setUseThreadLocal(true);
+	}
+
+}

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryWithBackoffNoThreadLocalTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryWithBackoffNoThreadLocalTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.annotation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.retry.support.RetrySynchronizationManager;
+
+/**
+ * @author Gary Russell
+ */
+public class EnableRetryWithBackoffNoThreadLocalTests extends EnableRetryWithBackoffTests {
+
+	@BeforeAll
+	static void before() {
+		RetrySynchronizationManager.setUseThreadLocal(false);
+	}
+
+	@AfterAll
+	static void after() {
+		RetrySynchronizationManager.setUseThreadLocal(true);
+	}
+
+}

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryWithBackoffTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryWithBackoffTests.java
@@ -75,7 +75,8 @@ public class EnableRetryWithBackoffTests {
 		List<Long> periods = context.getBean(PeriodSleeper.class).getPeriods();
 		assertThat(context.getBean(PeriodSleeper.class).getPeriods().toString()).isNotEqualTo("[1000, 1100]");
 		assertThat(periods.get(0) > 1000).describedAs("Wrong periods: %s" + periods.toString()).isTrue();
-		assertThat(periods.get(1) > 1100 && periods.get(1) < 1210).describedAs("Wrong periods: %s" + periods.toString())
+		assertThat(periods.get(1) >= 1100 && periods.get(1) < 1210)
+			.describedAs("Wrong periods: %s" + periods.toString())
 			.isTrue();
 		context.close();
 	}
@@ -89,7 +90,8 @@ public class EnableRetryWithBackoffTests {
 		List<Long> periods = context.getBean(PeriodSleeper.class).getPeriods();
 		assertThat(context.getBean(PeriodSleeper.class).getPeriods().toString()).isNotEqualTo("[1000, 1100]");
 		assertThat(periods.get(0) > 1000).describedAs("Wrong periods: %s" + periods.toString()).isTrue();
-		assertThat(periods.get(1) > 1100 && periods.get(1) < 1210).describedAs("Wrong periods: %s" + periods.toString())
+		assertThat(periods.get(1) >= 1100 && periods.get(1) < 1210)
+			.describedAs("Wrong periods: %s" + periods.toString())
 			.isTrue();
 		context.close();
 	}
@@ -138,11 +140,11 @@ public class EnableRetryWithBackoffTests {
 
 		@Override
 		public void sleep(long period) {
-			periods.add(period);
+			this.periods.add(period);
 		}
 
 		private List<Long> getPeriods() {
-			return periods;
+			return this.periods;
 		}
 
 	}
@@ -153,13 +155,13 @@ public class EnableRetryWithBackoffTests {
 
 		@Retryable(backoff = @Backoff(delay = 1000))
 		public void service() {
-			if (count++ < 2) {
+			if (this.count++ < 2) {
 				throw new RuntimeException("Planned");
 			}
 		}
 
 		public int getCount() {
-			return count;
+			return this.count;
 		}
 
 	}
@@ -170,13 +172,13 @@ public class EnableRetryWithBackoffTests {
 		private int count = 0;
 
 		public void service() {
-			if (count++ < 2) {
+			if (this.count++ < 2) {
 				throw new RuntimeException("Planned");
 			}
 		}
 
 		public int getCount() {
-			return count;
+			return this.count;
 		}
 
 	}
@@ -187,13 +189,13 @@ public class EnableRetryWithBackoffTests {
 
 		@Retryable(backoff = @Backoff(delay = 1000, maxDelay = 2000, multiplier = 1.1))
 		public void service() {
-			if (count++ < 2) {
+			if (this.count++ < 2) {
 				throw new IllegalStateException("Planned");
 			}
 		}
 
 		public int getCount() {
-			return count;
+			return this.count;
 		}
 
 	}
@@ -204,13 +206,13 @@ public class EnableRetryWithBackoffTests {
 
 		@Retryable(backoff = @Backoff(delay = 1000, maxDelay = 2000, multiplier = 1.1, random = true))
 		public void service(int value) {
-			if (count++ < 2) {
+			if (this.count++ < 2) {
 				throw new RuntimeException("Planned");
 			}
 		}
 
 		public int getCount() {
-			return count;
+			return this.count;
 		}
 
 	}
@@ -221,13 +223,13 @@ public class EnableRetryWithBackoffTests {
 
 		@Retryable(backoff = @Backoff(delay = 1000, maxDelay = 2000, multiplier = 1.1, randomExpression = "#{true}"))
 		public void service(int value) {
-			if (count++ < 2) {
+			if (this.count++ < 2) {
 				throw new RuntimeException("Planned");
 			}
 		}
 
 		public int getCount() {
-			return count;
+			return this.count;
 		}
 
 	}

--- a/src/test/java/org/springframework/retry/interceptor/RetryInterceptorBuilderTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/RetryInterceptorBuilderTests.java
@@ -19,7 +19,7 @@ import java.util.Collections;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Supplier;
+import java.util.function.Function;
 
 import org.aopalliance.intercept.MethodInterceptor;
 import org.junit.jupiter.api.Test;
@@ -80,6 +80,7 @@ public class RetryInterceptorBuilderTests {
 		assertThat(TestUtils.getPropertyValue(interceptor, "retryOperations.backOffPolicy.maxInterval")).isEqualTo(10L);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testWithCustomBackOffPolicy() {
 		StatefulRetryOperationsInterceptor interceptor = RetryInterceptorBuilder.stateful()
@@ -89,11 +90,12 @@ public class RetryInterceptorBuilderTests {
 
 		assertThat(TestUtils.getPropertyValue(interceptor, "retryOperations.retryPolicy.maxAttempts")).isEqualTo(5);
 		assertThat(
-				TestUtils.getPropertyValue(interceptor, "retryOperations.backOffPolicy.backOffPeriod", Supplier.class)
-					.get())
+				TestUtils.getPropertyValue(interceptor, "retryOperations.backOffPolicy.backOffPeriod", Function.class)
+					.apply(null))
 			.isEqualTo(1000L);
 	}
 
+	@SuppressWarnings("unchecked")
 	@Test
 	public void testWithCustomNewMessageIdentifier() throws Exception {
 		final CountDownLatch latch = new CountDownLatch(1);
@@ -108,8 +110,8 @@ public class RetryInterceptorBuilderTests {
 
 		assertThat(TestUtils.getPropertyValue(interceptor, "retryOperations.retryPolicy.maxAttempts")).isEqualTo(5);
 		assertThat(
-				TestUtils.getPropertyValue(interceptor, "retryOperations.backOffPolicy.backOffPeriod", Supplier.class)
-					.get())
+				TestUtils.getPropertyValue(interceptor, "retryOperations.backOffPolicy.backOffPeriod", Function.class)
+					.apply(null))
 			.isEqualTo(1000L);
 		final AtomicInteger count = new AtomicInteger();
 		Foo delegate = createDelegate(interceptor, count);

--- a/src/test/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptorTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/StatefulRetryOperationsInterceptorTests.java
@@ -70,8 +70,8 @@ public class StatefulRetryOperationsInterceptorTests {
 
 	@BeforeEach
 	public void setUp() {
-		interceptor = new StatefulRetryOperationsInterceptor();
-		retryTemplate.registerListener(new RetryListener() {
+		this.interceptor = new StatefulRetryOperationsInterceptor();
+		this.retryTemplate.registerListener(new RetryListener() {
 			@Override
 			public <T, E extends Throwable> void close(RetryContext context, RetryCallback<T, E> callback,
 					Throwable throwable) {
@@ -190,7 +190,7 @@ public class StatefulRetryOperationsInterceptorTests {
 		when(invocation.getArguments()).thenReturn(new Object[] { new Object() });
 		this.interceptor.invoke(invocation);
 		ArgumentCaptor<DefaultRetryState> captor = ArgumentCaptor.forClass(DefaultRetryState.class);
-		verify(template).execute(any(RetryCallback.class), eq(null), captor.capture());
+		verify(template).execute(any(RetryCallback.class), eq(null), captor.capture(), any());
 		assertThat(captor.getValue().getKey()).isNull();
 	}
 
@@ -206,7 +206,7 @@ public class StatefulRetryOperationsInterceptorTests {
 		when(invocation.getArguments()).thenReturn(new Object[] { new Object() });
 		this.interceptor.invoke(invocation);
 		ArgumentCaptor<DefaultRetryState> captor = ArgumentCaptor.forClass(DefaultRetryState.class);
-		verify(template).execute(any(RetryCallback.class), eq(null), captor.capture());
+		verify(template).execute(any(RetryCallback.class), eq(null), captor.capture(), any());
 		assertThat(captor.getValue().getKey()).isEqualTo("bar");
 	}
 

--- a/src/test/java/org/springframework/retry/support/RetrySynchronizationManagerNoThreadLocalTests.java
+++ b/src/test/java/org/springframework/retry/support/RetrySynchronizationManagerNoThreadLocalTests.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+import org.springframework.retry.RetryContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RetrySynchronizationManagerNoThreadLocalTests extends RetrySynchronizationManagerTests {
+
+	@BeforeAll
+	static void before() {
+		RetrySynchronizationManager.setUseThreadLocal(false);
+	}
+
+	@AfterAll
+	static void after() {
+		RetrySynchronizationManager.setUseThreadLocal(true);
+	}
+
+	@Override
+	@BeforeEach
+	public void setUp(TestInfo info) {
+		RetrySynchronizationManagerTests.clearAll();
+		RetryContext status = RetrySynchronizationManager.getContext("test");
+		assertThat(status).isNull();
+	}
+
+}

--- a/src/test/java/org/springframework/retry/support/RetryTemplateNoThreadLocalTests.java
+++ b/src/test/java/org/springframework/retry/support/RetryTemplateNoThreadLocalTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * @author Gary Russell
+ */
+public class RetryTemplateNoThreadLocalTests extends RetryTemplateTests {
+
+	@BeforeAll
+	static void before() {
+		RetrySynchronizationManager.setUseThreadLocal(false);
+	}
+
+	@AfterAll
+	static void after() {
+		RetrySynchronizationManager.setUseThreadLocal(true);
+	}
+
+}


### PR DESCRIPTION
* Add an option to store contexts in a map instead of a `ThreadLocal`
* Overloaded `execute` methods to accept a unique context key
* Propagate context to runtime expression evaluations (for method argument access)
* Subclass existing tests to verify functionality

Draft only, for review; need to subclass many more tests.