### PR TITLE
Add Option to Avoid Use of ThreadLocal

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,13 +166,18 @@ RetryTemplate.builder()
 
 ### Using `RetryContext`
 
-The method parameter for the `RetryCallback` is a `RetryContext`. Many callbacks ignore
-the context. However, if necessary, you can use it as an attribute bag to store data for
-the duration of the iteration.
+The method parameter for the `RetryCallback` is a `RetryContext`.
+Many callbacks ignore the context.
+However, if necessary, you can use it as an attribute bag to store data for the duration of the iteration.
+It also has some useful properties, such as `retryCount`.
 
-A `RetryContext` has a parent context if there is a nested retry in progress in the same
-thread. The parent context is occasionally useful for storing data that needs to be shared
-between calls to execute.
+A `RetryContext` has a parent context if there is a nested retry in progress in the same thread.
+The parent context is occasionally useful for storing data that needs to be shared between calls to execute.
+
+If you dont have access to the context directly, you can obtain the current context within the scope of the retries by calling `RetrySynchronizationManager.getContext()`.
+By default, the context is stored in a `ThreadLocal`.
+JEP 444 recommends that `ThreadLocal` should be avoided when using virtual threads, available in Java 21 and beyond.
+To store the contexts in a `Map` instead of a `ThreadLocal`, call `RetrySynchronizationManager.setUseThreadLocal(false)`.
 
 ### Using `RecoveryCallback`
 

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryNoThreadLocalTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryNoThreadLocalTests.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.annotation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.retry.support.RetrySynchronizationManager;
+
+public class EnableRetryNoThreadLocalTests extends EnableRetryTests {
+
+	@BeforeAll
+	static void before() {
+		RetrySynchronizationManager.setUseThreadLocal(false);
+	}
+
+	@AfterAll
+	static void after() {
+		RetrySynchronizationManager.setUseThreadLocal(true);
+	}
+
+}

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryWithBackoffNoThreadLocalTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryWithBackoffNoThreadLocalTests.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.annotation;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+import org.springframework.retry.support.RetrySynchronizationManager;
+
+/**
+ * @author Gary Russell
+ */
+public class EnableRetryWithBackoffNoThreadLocalTests extends EnableRetryWithBackoffTests {
+
+	@BeforeAll
+	static void before() {
+		RetrySynchronizationManager.setUseThreadLocal(false);
+	}
+
+	@AfterAll
+	static void after() {
+		RetrySynchronizationManager.setUseThreadLocal(true);
+	}
+
+}

--- a/src/test/java/org/springframework/retry/support/RetrySynchronizationManagerNoThreadLocalTests.java
+++ b/src/test/java/org/springframework/retry/support/RetrySynchronizationManagerNoThreadLocalTests.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+
+import org.springframework.retry.RetryContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RetrySynchronizationManagerNoThreadLocalTests extends RetrySynchronizationManagerTests {
+
+	@BeforeAll
+	static void before() {
+		RetrySynchronizationManager.setUseThreadLocal(false);
+	}
+
+	@AfterAll
+	static void after() {
+		RetrySynchronizationManager.setUseThreadLocal(true);
+	}
+
+	@Override
+	@BeforeEach
+	public void setUp() {
+		RetrySynchronizationManagerTests.clearAll();
+		RetryContext status = RetrySynchronizationManager.getContext();
+		assertThat(status).isNull();
+	}
+
+}

--- a/src/test/java/org/springframework/retry/support/RetryTemplateNoThreadLocalTests.java
+++ b/src/test/java/org/springframework/retry/support/RetryTemplateNoThreadLocalTests.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2023 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.springframework.retry.support;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+
+/**
+ * @author Gary Russell
+ */
+public class RetryTemplateNoThreadLocalTests extends RetryTemplateTests {
+
+	@BeforeAll
+	static void before() {
+		RetrySynchronizationManager.setUseThreadLocal(false);
+	}
+
+	@AfterAll
+	static void after() {
+		RetrySynchronizationManager.setUseThreadLocal(true);
+	}
+
+}


### PR DESCRIPTION
* Add an option to store contexts in a map instead of a `ThreadLocal`
* Subclass existing tests to verify functionality