### PR TITLE
GH-383: maxAttemptsExpression Ignored Sometimes

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -352,7 +352,7 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 		@SuppressWarnings("unchecked")
 		Class<? extends Throwable>[] includes = (Class<? extends Throwable>[]) attrs.get("value");
 		String exceptionExpression = (String) attrs.get("exceptionExpression");
-		boolean hasExpression = StringUtils.hasText(exceptionExpression);
+		boolean hasExceptionExpression = StringUtils.hasText(exceptionExpression);
 		if (includes.length == 0) {
 			@SuppressWarnings("unchecked")
 			Class<? extends Throwable>[] value = (Class<? extends Throwable>[]) attrs.get("retryFor");
@@ -370,14 +370,14 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 				parsedExpression = null;
 			}
 		}
-		final Expression expression = parsedExpression;
+		final Expression maxAttExpression = parsedExpression;
 		SimpleRetryPolicy simple = null;
 		if (includes.length == 0 && excludes.length == 0) {
-			simple = hasExpression
+			simple = hasExceptionExpression
 					? new ExpressionRetryPolicy(resolve(exceptionExpression)).withBeanFactory(this.beanFactory)
 					: new SimpleRetryPolicy();
-			if (expression != null) {
-				simple.maxAttemptsSupplier(() -> evaluate(expression, Integer.class, stateless));
+			if (maxAttExpression != null) {
+				simple.maxAttemptsSupplier(() -> evaluate(maxAttExpression, Integer.class, stateless));
 			}
 			else {
 				simple.setMaxAttempts(maxAttempts);
@@ -392,16 +392,16 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 		}
 		boolean retryNotExcluded = includes.length == 0;
 		if (simple == null) {
-			if (hasExpression) {
+			if (hasExceptionExpression) {
 				simple = new ExpressionRetryPolicy(maxAttempts, policyMap, true, resolve(exceptionExpression),
 						retryNotExcluded)
 					.withBeanFactory(this.beanFactory);
 			}
 			else {
 				simple = new SimpleRetryPolicy(maxAttempts, policyMap, true, retryNotExcluded);
-				if (expression != null) {
-					simple.maxAttemptsSupplier(() -> evaluate(expression, Integer.class, stateless));
-				}
+			}
+			if (maxAttExpression != null) {
+				simple.maxAttemptsSupplier(() -> evaluate(maxAttExpression, Integer.class, stateless));
 			}
 		}
 		@SuppressWarnings("unchecked")

--- a/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
+++ b/src/test/java/org/springframework/retry/annotation/EnableRetryTests.java
@@ -560,22 +560,22 @@ public class EnableRetryTests {
 		int count = 0;
 
 		public int getMaxAttempts() {
-			count++;
+			this.count++;
 			return 3;
 		}
 
 		public long getInitial() {
-			count++;
+			this.count++;
 			return 1000;
 		}
 
 		public long getMax() {
-			count++;
+			this.count++;
 			return 2000;
 		}
 
 		public double getMult() {
-			count++;
+			this.count++;
 			return 1.2;
 		}
 
@@ -639,10 +639,10 @@ public class EnableRetryTests {
 		@Retryable(retryFor = RuntimeException.class, noRetryFor = IllegalStateException.class,
 				notRecoverable = { IllegalArgumentException.class, IllegalStateException.class })
 		public void service() {
-			if (this.count++ >= 3 && count < 7) {
+			if (this.count++ >= 3 && this.count < 7) {
 				throw new IllegalArgumentException("Planned");
 			}
-			else if (count > 6) {
+			else if (this.count > 6) {
 				throw new IllegalStateException("Planned");
 			}
 			else {
@@ -801,7 +801,7 @@ public class EnableRetryTests {
 			throw new RuntimeException("this cannot be retried");
 		}
 
-		@Retryable(exceptionExpression = "@exceptionChecker.${retryMethod}(#root)",
+		@Retryable(exceptionExpression = "@exceptionChecker.${retryMethod}(#root)", retryFor = RuntimeException.class,
 				maxAttemptsExpression = "@integerFiveBean", backoff = @Backoff(delayExpression = "${one}",
 						maxDelayExpression = "@integerFiveBean", multiplierExpression = "${onePointOne}"))
 		public void service3() {


### PR DESCRIPTION
Resolves https://github.com/spring-projects/spring-retry/issues/383

If explicit exceptions are referenced, and an `exceptionExpression` is provided, the `maxAttemptsExpression` was ignored.