### PR TITLE
GH-211: Provide the ability to exclude global retryListeners

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -75,6 +75,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Roman Akentev
  * @since 1.1
  */
 public class AnnotationAwareRetryOperationsInterceptor implements IntroductionInterceptor, BeanFactoryAware {
@@ -323,6 +324,9 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 	}
 
 	private RetryListener[] getListenersBeans(String[] listenersBeanNames) {
+		if (listenersBeanNames.length == 1 && "".equals(listenersBeanNames[0].trim())) {
+			return new RetryListener[0];
+		}
 		RetryListener[] listeners = new RetryListener[listenersBeanNames.length];
 		for (int i = 0; i < listeners.length; i++) {
 			listeners[i] = this.beanFactory.getBean(listenersBeanNames[i], RetryListener.class);

--- a/src/main/java/org/springframework/retry/annotation/Retryable.java
+++ b/src/main/java/org/springframework/retry/annotation/Retryable.java
@@ -167,8 +167,8 @@ public @interface Retryable {
 	/**
 	 * Bean names of retry listeners to use instead of default ones defined in Spring
 	 * context. If this attribute is set to an empty string {@code ""}, it will
-	 * effectively exclude all retry listeners, including with the default listener beans, from being
-	 * used.
+	 * effectively exclude all retry listeners, including with the default listener beans,
+	 * from being used.
 	 * @return retry listeners bean names
 	 */
 	String[] listeners() default {};

--- a/src/main/java/org/springframework/retry/annotation/Retryable.java
+++ b/src/main/java/org/springframework/retry/annotation/Retryable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.core.annotation.AliasFor;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Maksim Kita
+ * @author Roman Akentev
  * @since 1.1
  *
  */
@@ -165,7 +166,9 @@ public @interface Retryable {
 
 	/**
 	 * Bean names of retry listeners to use instead of default ones defined in Spring
-	 * context
+	 * context. If this attribute is set to an empty string {@code ""}, it will
+	 * effectively exclude all retry listeners, along with the default ones, from being
+	 * used.
 	 * @return retry listeners bean names
 	 */
 	String[] listeners() default {};

--- a/src/main/java/org/springframework/retry/annotation/Retryable.java
+++ b/src/main/java/org/springframework/retry/annotation/Retryable.java
@@ -167,7 +167,7 @@ public @interface Retryable {
 	/**
 	 * Bean names of retry listeners to use instead of default ones defined in Spring
 	 * context. If this attribute is set to an empty string {@code ""}, it will
-	 * effectively exclude all retry listeners, along with the default ones, from being
+	 * effectively exclude all retry listeners, including with the default listener beans, from being
 	 * used.
 	 * @return retry listeners bean names
 	 */


### PR DESCRIPTION
Hey folks,
I was evaluating this library in detail for the use in our enterprise project and came across an issue that seemed rather trivial to carry out an implementation for as per @artembilan's suggestion here: https://github.com/spring-projects/spring-retry/issues/211#issuecomment-1761945504. 

To the best of my knowledge this implementation is fully reverse-compatible.

Please refer to GH-211 for more context if necessary.

upd: made a few corrections that felt right after a good night's sleep 😄

