### PR TITLE
GH-211: handle non-existent retry listeners

### DIFF
--- a/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/annotation/AnnotationAwareRetryOperationsInterceptor.java
@@ -75,6 +75,7 @@ import org.springframework.util.StringUtils;
  * @author Dave Syer
  * @author Artem Bilan
  * @author Gary Russell
+ * @author Donghyeok Jang
  * @since 1.1
  */
 public class AnnotationAwareRetryOperationsInterceptor implements IntroductionInterceptor, BeanFactoryAware {
@@ -323,9 +324,17 @@ public class AnnotationAwareRetryOperationsInterceptor implements IntroductionIn
 	}
 
 	private RetryListener[] getListenersBeans(String[] listenersBeanNames) {
-		RetryListener[] listeners = new RetryListener[listenersBeanNames.length];
-		for (int i = 0; i < listeners.length; i++) {
-			listeners[i] = this.beanFactory.getBean(listenersBeanNames[i], RetryListener.class);
+		int numListenersBeans = listenersBeanNames.length;
+		for (int i = 0; i < listenersBeanNames.length; i++) {
+			if (!this.beanFactory.containsBean(listenersBeanNames[i])) {
+				numListenersBeans--;
+			}
+		}
+		RetryListener[] listeners = new RetryListener[numListenersBeans];
+		for (int i = 0; i < listenersBeanNames.length; i++) {
+			if (this.beanFactory.containsBean(listenersBeanNames[i])) {
+				listeners[i] = this.beanFactory.getBean(listenersBeanNames[i], RetryListener.class);
+			}
 		}
 		return listeners;
 	}

--- a/src/main/java/org/springframework/retry/annotation/Retryable.java
+++ b/src/main/java/org/springframework/retry/annotation/Retryable.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2014-2022 the original author or authors.
+ * Copyright 2014-2023 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -31,6 +31,7 @@ import org.springframework.core.annotation.AliasFor;
  * @author Artem Bilan
  * @author Gary Russell
  * @author Maksim Kita
+ * @author Donghyeok Jang
  * @since 1.1
  *
  */
@@ -165,7 +166,9 @@ public @interface Retryable {
 
 	/**
 	 * Bean names of retry listeners to use instead of default ones defined in Spring
-	 * context
+	 * context. However, If this attribute is set to the name of a non-existent retry
+	 * listener, not only the default ones but also a non-existent retry listener,
+	 * is not set.
 	 * @return retry listeners bean names
 	 */
 	String[] listeners() default {};


### PR DESCRIPTION
Hi. Guys.

I wanted to handle [GH-211](https://github.com/spring-projects/spring-retry/issues/211) issue, and @artembilan gave me a good suggestion. I came up with two ways and was preparing two different PRs.
The first is to literally ignore all listeners when the `listeners` attribute is set to `""`.
The second is that when the `listeners` attribute is set to a non-existent listener, it will have the same effect as a listener without any configuration.

The first implementation seems to have been implemented nicely by akenra in [this PR](https://github.com/spring-projects/spring-retry/pull/392). So, I'm posting a PR for the second implementation as well.
