### PR TITLE
Add @Nullable in RetryContext to easier detect possible NPE

### DIFF
--- a/src/main/java/org/springframework/retry/RetryContext.java
+++ b/src/main/java/org/springframework/retry/RetryContext.java
@@ -25,6 +25,7 @@ import org.springframework.lang.Nullable;
  *
  * @author Dave Syer
  * @author Emanuele Ivaldi
+ * @author Marcin Zajączkowski
  *
  */
 public interface RetryContext extends AttributeAccessor {
@@ -99,8 +100,9 @@ public interface RetryContext extends AttributeAccessor {
 	/**
 	 * Accessor for the exception object that caused the current retry.
 	 * @return the last exception that caused a retry, or possibly null. It will be null
-	 * if this is the first attempt and it finishes successfully, but also if the enclosing
-	 * policy decides not to provide it (e.g. because of concerns about memory usage).
+	 * if this is the first attempt and it finishes successfully, but also if the
+	 * enclosing policy decides not to provide it (e.g. because of concerns about memory
+	 * usage).
 	 */
 	@Nullable
 	Throwable getLastThrowable();

--- a/src/main/java/org/springframework/retry/RetryContext.java
+++ b/src/main/java/org/springframework/retry/RetryContext.java
@@ -99,8 +99,8 @@ public interface RetryContext extends AttributeAccessor {
 	/**
 	 * Accessor for the exception object that caused the current retry.
 	 * @return the last exception that caused a retry, or possibly null. It will be null
-	 * if this is the first attempt, but also if the enclosing policy decides not to
-	 * provide it (e.g. because of concerns about memory usage).
+	 * if this is the first attempt and it finishes successfully, but also if the enclosing
+	 * policy decides not to provide it (e.g. because of concerns about memory usage).
 	 */
 	@Nullable
 	Throwable getLastThrowable();

--- a/src/main/java/org/springframework/retry/RetryContext.java
+++ b/src/main/java/org/springframework/retry/RetryContext.java
@@ -17,6 +17,7 @@
 package org.springframework.retry;
 
 import org.springframework.core.AttributeAccessor;
+import org.springframework.lang.Nullable;
 
 /**
  * Low-level access to ongoing retry operation. Normally not needed by clients, but can be
@@ -85,6 +86,7 @@ public interface RetryContext extends AttributeAccessor {
 	 * Accessor for the parent context if retry blocks are nested.
 	 * @return the parent or null if there is none.
 	 */
+	@Nullable
 	RetryContext getParent();
 
 	/**
@@ -100,6 +102,7 @@ public interface RetryContext extends AttributeAccessor {
 	 * if this is the first attempt, but also if the enclosing policy decides not to
 	 * provide it (e.g. because of concerns about memory usage).
 	 */
+	@Nullable
 	Throwable getLastThrowable();
 
 }


### PR DESCRIPTION
Both `getParent()` and `getLastThrowable()` might return null, as mentioned in javadoc. `@Nullable` helps an IDE warns developers about potential NPE.

It is a reminiscence of the problem, I've encountered recently, incorrectly assuming that `onSuccess` will only be executed if there was at least failed attempt before (which resulted in no throwable and NPE).