### PR TITLE
Fix backOff API in UniformRandomBackOffPolicy

### DIFF
--- a/src/main/java/org/springframework/retry/backoff/UniformRandomBackOffPolicy.java
+++ b/src/main/java/org/springframework/retry/backoff/UniformRandomBackOffPolicy.java
@@ -134,7 +134,7 @@ public class UniformRandomBackOffPolicy extends StatelessBackOffPolicy
 	protected void doBackOff() throws BackOffInterruptedException {
 		try {
 			Long min = this.minBackOffPeriod.get();
-			long delta = this.maxBackOffPeriod.get() == this.minBackOffPeriod.get() ? 0
+			long delta = this.maxBackOffPeriod.get() <= this.minBackOffPeriod.get() ? 0
 					: this.random.nextInt((int) (this.maxBackOffPeriod.get() - min));
 			this.sleeper.sleep(min + delta);
 		}

--- a/src/main/java/org/springframework/retry/backoff/UniformRandomBackOffPolicy.java
+++ b/src/main/java/org/springframework/retry/backoff/UniformRandomBackOffPolicy.java
@@ -134,7 +134,7 @@ public class UniformRandomBackOffPolicy extends StatelessBackOffPolicy
 	protected void doBackOff() throws BackOffInterruptedException {
 		try {
 			Long min = this.minBackOffPeriod.get();
-			Long max = this.minBackOffPeriod.get();
+			Long max = this.maxBackOffPeriod.get();
 			long delta = max <= min ? 0 : this.random.nextInt((int) (max - min));
 			this.sleeper.sleep(min + delta);
 		}

--- a/src/main/java/org/springframework/retry/backoff/UniformRandomBackOffPolicy.java
+++ b/src/main/java/org/springframework/retry/backoff/UniformRandomBackOffPolicy.java
@@ -134,8 +134,8 @@ public class UniformRandomBackOffPolicy extends StatelessBackOffPolicy
 	protected void doBackOff() throws BackOffInterruptedException {
 		try {
 			Long min = this.minBackOffPeriod.get();
-			long delta = this.maxBackOffPeriod.get() <= this.minBackOffPeriod.get() ? 0
-					: this.random.nextInt((int) (this.maxBackOffPeriod.get() - min));
+			Long max = this.minBackOffPeriod.get();
+			long delta = max <= min ? 0 : this.random.nextInt((int) (max - min));
 			this.sleeper.sleep(min + delta);
 		}
 		catch (InterruptedException e) {

--- a/src/test/java/org/springframework/retry/backoff/UniformRandomBackOffPolicyTests.java
+++ b/src/test/java/org/springframework/retry/backoff/UniformRandomBackOffPolicyTests.java
@@ -36,10 +36,18 @@ public class UniformRandomBackOffPolicyTests {
 		int maxBackOff = 10000;
 		backOffPolicy.setMinBackOffPeriod(minBackOff);
 		backOffPolicy.setMaxBackOffPeriod(maxBackOff);
-		UniformRandomBackOffPolicy withSleeper = backOffPolicy.withSleeper(new DummySleeper());
+
+		DummySleeper dummySleeper = new DummySleeper();
+		UniformRandomBackOffPolicy withSleeper = backOffPolicy.withSleeper(dummySleeper);
 
 		assertThat(withSleeper.getMinBackOffPeriod()).isEqualTo(minBackOff);
 		assertThat(withSleeper.getMaxBackOffPeriod()).isEqualTo(maxBackOff);
+
+		assertThat(dummySleeper.getBackOffs()).isEmpty();
+		withSleeper.backOff(null);
+
+		assertThat(dummySleeper.getBackOffs()).hasSize(1);
+		assertThat(dummySleeper.getBackOffs()[0]).isLessThan(maxBackOff);
 	}
 
 	@Test
@@ -61,7 +69,7 @@ public class UniformRandomBackOffPolicyTests {
 	}
 
 	@Test
-	public void testMaxBackOffLessThanMinBackOff() throws InterruptedException {
+	public void testMaxBackOffLessThanMinBackOff() {
 		UniformRandomBackOffPolicy backOffPolicy = new UniformRandomBackOffPolicy();
 		int minBackOff = 1000;
 		int maxBackOff = 10;
@@ -72,7 +80,8 @@ public class UniformRandomBackOffPolicyTests {
 		UniformRandomBackOffPolicy withSleeper = backOffPolicy.withSleeper(dummySleeper);
 		assertThat(dummySleeper.getBackOffs()).isEmpty();
 		withSleeper.backOff(null);
-		assertThat(dummySleeper.getBackOffs()).isNotEmpty();
+		assertThat(dummySleeper.getBackOffs()).hasSize(1);
+		assertThat(dummySleeper.getBackOffs()[0]).isEqualTo(minBackOff);
 	}
 
 }

--- a/src/test/java/org/springframework/retry/backoff/UniformRandomBackOffPolicyTests.java
+++ b/src/test/java/org/springframework/retry/backoff/UniformRandomBackOffPolicyTests.java
@@ -18,9 +18,6 @@ package org.springframework.retry.backoff;
 
 import org.junit.jupiter.api.Test;
 
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
@@ -70,16 +67,12 @@ public class UniformRandomBackOffPolicyTests {
 		int maxBackOff = 10;
 		backOffPolicy.setMinBackOffPeriod(minBackOff);
 		backOffPolicy.setMaxBackOffPeriod(maxBackOff);
-		CountDownLatch stopLatch = new CountDownLatch(1);
 
-		UniformRandomBackOffPolicy withSleeper = backOffPolicy.withSleeper(new Sleeper() {
-			@Override
-			public void sleep(long backOffPeriod) throws InterruptedException {
-				stopLatch.countDown();
-			}
-		});
+		DummySleeper dummySleeper = new DummySleeper();
+		UniformRandomBackOffPolicy withSleeper = backOffPolicy.withSleeper(dummySleeper);
+		assertThat(dummySleeper.getBackOffs()).isEmpty();
 		withSleeper.backOff(null);
-		assertThat(stopLatch.await(10, TimeUnit.SECONDS)).isTrue();
+		assertThat(dummySleeper.getBackOffs()).isNotEmpty();
 	}
 
 }


### PR DESCRIPTION
When maxBackOffPeriod is less than minBackOffPeriod, delta is taken taken as zero in UniformRandomBackOffPolicy backOff method.