### PR TITLE
feat: setter for logger field of RetryTemplate

### DIFF
--- a/src/main/java/org/springframework/retry/support/RetryTemplate.java
+++ b/src/main/java/org/springframework/retry/support/RetryTemplate.java
@@ -78,6 +78,7 @@ import org.springframework.util.Assert;
  * @author Josh Long
  * @author Aleksandr Shamukov
  * @author Emanuele Ivaldi
+ * @author Tobias Soloschenko
  */
 public class RetryTemplate implements RetryOperations {
 
@@ -87,7 +88,7 @@ public class RetryTemplate implements RetryOperations {
 	 */
 	private static final String GLOBAL_STATE = "state.global";
 
-	protected final Log logger = LogFactory.getLog(getClass());
+	protected Log logger = LogFactory.getLog(getClass());
 
 	private volatile BackOffPolicy backOffPolicy = new NoBackOffPolicy();
 
@@ -184,6 +185,18 @@ public class RetryTemplate implements RetryOperations {
 	 */
 	public boolean hasListeners() {
 		return this.listeners.length > 0;
+	}
+
+	/**
+	 * Setter for {@link Log}. If not applied the following is used:
+	 * <p>
+	 * {@code LogFactory.getLog(getClass())}
+	 * </p>
+	 * @param logger the logger the retry template uses for logging
+	 * @since 2.0.10
+	 */
+	public void setLogger(Log logger) {
+		this.logger = logger;
 	}
 
 	/**

--- a/src/test/java/org/springframework/retry/support/RetryTemplateBuilderTests.java
+++ b/src/test/java/org/springframework/retry/support/RetryTemplateBuilderTests.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.Predicate;
 
+import org.apache.commons.logging.Log;
 import org.junit.jupiter.api.Test;
 import org.springframework.classify.BinaryExceptionClassifier;
 import org.springframework.retry.RetryListener;
@@ -58,6 +59,7 @@ import static org.springframework.retry.util.test.TestUtils.getPropertyValue;
  * @author Gary Russell
  * @author Andreas Ahlenstorf
  * @author Morulai Planinski
+ * @author Tobias Soloschenko
  */
 public class RetryTemplateBuilderTests {
 
@@ -344,6 +346,21 @@ public class RetryTemplateBuilderTests {
 	public void testValidateZeroInitInterval() {
 		assertThatIllegalArgumentException()
 			.isThrownBy(() -> RetryTemplate.builder().exponentialBackoff(0, 2, 200).build());
+	}
+
+	@Test
+	public void testBuilderWithLogger() {
+		Log logMock = mock(Log.class);
+		RetryTemplate retryTemplate = RetryTemplate.builder().withLogger(logMock).build();
+		Log logger = getPropertyValue(retryTemplate, "logger", Log.class);
+		assertThat(logger).isEqualTo(logMock);
+	}
+
+	@Test
+	public void testBuilderWithDefaultLogger() {
+		RetryTemplate retryTemplate = RetryTemplate.builder().build();
+		Log logger = getPropertyValue(retryTemplate, "logger", Log.class);
+		assertThat(logger).isNotNull();
 	}
 
 	/* ---------------- Utils -------------- */


### PR DESCRIPTION
fixes: https://github.com/spring-projects/spring-retry/issues/470

Because there is no Auto-Configuration I think it is fine to just add the hint without restrictions or class checks.