### PR TITLE
GH-480: Bring back POM `revision` property

### DIFF
--- a/.github/actions/build/action.yml
+++ b/.github/actions/build/action.yml
@@ -39,6 +39,6 @@ runs:
       id: read-version
       shell: bash
       run: |
-        version=$(mvn help:evaluate -Dexpression="project.version" -q -DforceStdout)
+        version=$(sed -n 's/^.*<revision>\(.*\)<\/revision>.*$/\1/p' pom.xml)
         echo "Version is $version"
         echo "version=$version" >> $GITHUB_OUTPUT

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>org.springframework.retry</groupId>
 	<artifactId>spring-retry</artifactId>
-	<version>2.0.12-SNAPSHOT</version>
+	<version>${revision}</version>
 	<name>Spring Retry</name>
 	<description><![CDATA[
 		Spring Retry provides an abstraction around retrying failed operations, with an
@@ -26,6 +26,7 @@
 		</license>
 	</licenses>
 	<properties>
+		<revision>2.0.12-SNAPSHOT</revision>
 		<disable.checks>false</disable.checks>
 		<java.version>17</java.version>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -298,6 +299,31 @@
 						<phase>package</phase>
 						<goals>
 							<goal>single</goal>
+						</goals>
+					</execution>
+				</executions>
+			</plugin>
+			<plugin>
+				<groupId>org.codehaus.mojo</groupId>
+				<artifactId>flatten-maven-plugin</artifactId>
+				<version>1.6.0</version>
+				<configuration>
+					<outputDirectory>${project.build.directory}</outputDirectory>
+					<flattenMode>oss</flattenMode>
+				</configuration>
+				<executions>
+					<execution>
+						<id>flatten</id>
+						<phase>process-resources</phase>
+						<goals>
+							<goal>flatten</goal>
+						</goals>
+					</execution>
+					<execution>
+						<id>flatten.clean</id>
+						<phase>clean</phase>
+						<goals>
+							<goal>clean</goal>
 						</goals>
 					</execution>
 				</executions>

--- a/pom.xml
+++ b/pom.xml
@@ -310,6 +310,9 @@
 				<configuration>
 					<outputDirectory>${project.build.directory}</outputDirectory>
 					<flattenMode>oss</flattenMode>
+					<pomElements>
+						<profiles>remove</profiles>
+					</pomElements>
 				</configuration>
 				<executions>
 					<execution>
@@ -317,13 +320,6 @@
 						<phase>process-resources</phase>
 						<goals>
 							<goal>flatten</goal>
-						</goals>
-					</execution>
-					<execution>
-						<id>flatten.clean</id>
-						<phase>clean</phase>
-						<goals>
-							<goal>clean</goal>
 						</goals>
 					</execution>
 				</executions>


### PR DESCRIPTION
Fixes: https://github.com/spring-projects/spring-retry/issues/480

* Add `flatten-maven-plugin` to resolve properties and remove unnecessary build info from the final POM of the artifact to install/deploy