### PR TITLE
Fix proxy attribute name mismatch in RetryOperationsInterceptor

### DIFF
--- a/src/main/java/org/springframework/retry/interceptor/RetryOperationsInterceptor.java
+++ b/src/main/java/org/springframework/retry/interceptor/RetryOperationsInterceptor.java
@@ -137,7 +137,7 @@ public class RetryOperationsInterceptor implements MethodInterceptor {
 		finally {
 			RetryContext context = RetrySynchronizationManager.getContext();
 			if (context != null) {
-				context.removeAttribute("__proxy__");
+				context.removeAttribute("___proxy___");
 			}
 		}
 	}

--- a/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2006-2023 the original author or authors.
+ * Copyright 2006-2025 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -49,6 +49,8 @@ import org.springframework.util.ClassUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * @author Dave Syer
@@ -287,39 +289,17 @@ public class RetryOperationsInterceptorTests {
 	}
 
 	@Test
-	public void testProxyAttributeCleanupEvenWhenIllegalStateExceptionThrown() {
+	public void testProxyAttributeCleanupEvenWhenIllegalStateExceptionThrown() throws NoSuchMethodException {
 		RetryContext context = new RetryContextSupport(null);
 		Object mockProxy = new Object();
 		RetrySynchronizationManager.register(context);
 		context.setAttribute("___proxy___", mockProxy);
 		assertThat(context.getAttribute("___proxy___")).isNotNull();
-		assertThatIllegalStateException().isThrownBy(() -> this.interceptor.invoke(new MethodInvocation() {
-			@Override
-			public Method getMethod() {
-				return ClassUtils.getMethod(RetryOperationsInterceptorTests.class,
-						"testProxyAttributeCleanupEvenWhenIllegalStateExceptionThrown");
-			}
-
-			@Override
-			public Object[] getArguments() {
-				return new Object[0];
-			}
-
-			@Override
-			public Object proceed() {
-				return null;
-			}
-
-			@Override
-			public Object getThis() {
-				return new Object();
-			}
-
-			@Override
-			public AccessibleObject getStaticPart() {
-				return null;
-			}
-		})).withMessageContaining("MethodInvocation");
+		MethodInvocation mockInvocation = mock(MethodInvocation.class);
+		Method testMethod = this.getClass().getMethod("testProxyAttributeCleanupEvenWhenIllegalStateExceptionThrown");
+		when(mockInvocation.getMethod()).thenReturn(testMethod);
+		assertThatIllegalStateException().isThrownBy(() -> this.interceptor.invoke(mockInvocation))
+			.withMessageContaining("MethodInvocation");
 		assertThat(context.getAttribute("___proxy___")).isNull();
 		RetrySynchronizationManager.clear();
 	}

--- a/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
@@ -58,6 +58,7 @@ import static org.junit.jupiter.api.Assertions.fail;
  * @author Stéphane Nicoll
  * @author Henning Pöttker
  * @author Artem Bilan
+ * @author Kim Jun Hyeong
  */
 public class RetryOperationsInterceptorTests {
 

--- a/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
@@ -36,9 +36,11 @@ import org.springframework.context.support.ClassPathXmlApplicationContext;
 import org.springframework.retry.RetryCallback;
 import org.springframework.retry.RetryContext;
 import org.springframework.retry.RetryListener;
+import org.springframework.retry.context.RetryContextSupport;
 import org.springframework.retry.listener.MethodInvocationRetryListenerSupport;
 import org.springframework.retry.policy.NeverRetryPolicy;
 import org.springframework.retry.policy.SimpleRetryPolicy;
+import org.springframework.retry.support.RetrySynchronizationManager;
 import org.springframework.retry.support.RetryTemplate;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
@@ -47,6 +49,7 @@ import org.springframework.util.ClassUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Dave Syer
@@ -255,6 +258,70 @@ public class RetryOperationsInterceptorTests {
 				return null;
 			}
 		})).withMessageContaining("MethodInvocation");
+	}
+
+	@Test
+	public void testProxyAttributeCleanupWithCorrectKey() {
+		RetryContext directContext = new RetryContextSupport(null);
+		Object mockProxy = new Object();
+		RetrySynchronizationManager.register(directContext);
+		directContext.setAttribute("___proxy___", mockProxy);
+		RetryContext retrievedContext = RetrySynchronizationManager.getContext();
+		retrievedContext.removeAttribute("___proxy___");
+		assertThat(RetrySynchronizationManager.getContext().getAttribute("___proxy___")).isNull();
+		RetrySynchronizationManager.clear();
+	}
+
+	@Test
+	public void testProxyAttributeRemainWithWrongKey() {
+		RetryContext directContext = new RetryContextSupport(null);
+		Object mockProxy = new Object();
+		RetrySynchronizationManager.register(directContext);
+		directContext.setAttribute("___proxy___", mockProxy);
+		RetryContext retrievedContext = RetrySynchronizationManager.getContext();
+		retrievedContext.removeAttribute("__proxy__");
+		Object remainingProxy = RetrySynchronizationManager.getContext().getAttribute("___proxy___");
+		assertThat(remainingProxy).isNotNull();
+		assertThat(remainingProxy).isSameAs(mockProxy);
+		RetrySynchronizationManager.clear();
+	}
+
+	@Test
+	public void testProxyAttributeCleanupEvenWhenIllegalStateExceptionThrown() {
+		RetryContext context = new RetryContextSupport(null);
+		Object mockProxy = new Object();
+		RetrySynchronizationManager.register(context);
+		context.setAttribute("___proxy___", mockProxy);
+		assertThat(context.getAttribute("___proxy___")).isNotNull();
+		assertThatIllegalStateException().isThrownBy(() -> this.interceptor.invoke(new MethodInvocation() {
+			@Override
+			public Method getMethod() {
+				return ClassUtils.getMethod(RetryOperationsInterceptorTests.class,
+						"testProxyAttributeCleanupEvenWhenIllegalStateExceptionThrown");
+			}
+
+			@Override
+			public Object[] getArguments() {
+				return new Object[0];
+			}
+
+			@Override
+			public Object proceed() {
+				return null;
+			}
+
+			@Override
+			public Object getThis() {
+				return new Object();
+			}
+
+			@Override
+			public AccessibleObject getStaticPart() {
+				return null;
+			}
+		})).withMessageContaining("MethodInvocation");
+		assertThat(context.getAttribute("___proxy___")).isNull();
+		RetrySynchronizationManager.clear();
 	}
 
 	public static interface Service {

--- a/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
+++ b/src/test/java/org/springframework/retry/interceptor/RetryOperationsInterceptorTests.java
@@ -49,7 +49,6 @@ import org.springframework.util.ClassUtils;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
-import static org.junit.jupiter.api.Assertions.fail;
 
 /**
  * @author Dave Syer


### PR DESCRIPTION
* Changed removeAttribute to use the same key as setAttribute("___proxy___").
* Fixed an issue where a proxy reference remained in the context due to the previous "__proxy__" key mismatch. 

Found a small bug: I might be mistaken, but I think the proxy key mismatch is preventing removal. Please have your team take a look when you have a moment. Thanks!