### PR TITLE
Add warnings for invalid setter values in ExponentialBackoffPolicy

### DIFF
--- a/src/main/java/org/springframework/retry/backoff/ExponentialBackOffPolicy.java
+++ b/src/main/java/org/springframework/retry/backoff/ExponentialBackOffPolicy.java
@@ -43,6 +43,7 @@ import org.springframework.util.ClassUtils;
  * @author Artem Bilan
  * @author Marius Lichtblau
  * @author Anton Aharkau
+ * @author Kim Sumin
  */
 @SuppressWarnings("serial")
 public class ExponentialBackOffPolicy implements SleepingBackOffPolicy<ExponentialBackOffPolicy> {
@@ -130,6 +131,9 @@ public class ExponentialBackOffPolicy implements SleepingBackOffPolicy<Exponenti
 	 * @param initialInterval the initial interval
 	 */
 	public void setInitialInterval(long initialInterval) {
+		if (initialInterval < 1) {
+			logger.warn("Initial interval must be at least 1, but was " + initialInterval);
+		}
 		this.initialInterval = initialInterval > 1 ? initialInterval : 1;
 	}
 
@@ -139,6 +143,9 @@ public class ExponentialBackOffPolicy implements SleepingBackOffPolicy<Exponenti
 	 * @param multiplier the multiplier
 	 */
 	public void setMultiplier(double multiplier) {
+		if (multiplier <= 1.0) {
+			logger.warn("Multiplier must be > 1.0 for effective exponential backoff, but was " + multiplier);
+		}
 		this.multiplier = multiplier > 1.0 ? multiplier : 1.0;
 	}
 
@@ -150,6 +157,9 @@ public class ExponentialBackOffPolicy implements SleepingBackOffPolicy<Exponenti
 	 * @param maxInterval in milliseconds.
 	 */
 	public void setMaxInterval(long maxInterval) {
+		if (maxInterval < 1) {
+			logger.warn("Max interval must be positive, but was " + maxInterval);
+		}
 		this.maxInterval = maxInterval > 0 ? maxInterval : 1;
 	}
 


### PR DESCRIPTION
This PR addresses #352 by adding warning logs when invalid values are provided to ExponentialBackoffPolicy setters.

## Changes
- Added warning logs in `setInitialInterval()` when value < 1
- Added warning logs in `setMultiplier()` when value <= 1.0
- Added warning logs in `setMaxInterval()` when value <= 0

## Motivation
The current implementation silently adjusts invalid values without informing users. This can lead to confusion when configured values differ from actual behavior. Adding warning logs helps users understand when their configuration needs adjustment.

## Backward Compatibility
This change maintains backward compatibility by:
- Keeping the existing behavior of silently adjusting invalid values
- Only adding warning logs to inform users
- No breaking changes to the API

## Related Issue
Closes #352